### PR TITLE
Fix links

### DIFF
--- a/create-template-documents-for-github-repositories.md
+++ b/create-template-documents-for-github-repositories.md
@@ -84,15 +84,15 @@ We started with a TL:DR about preparing for contributions but this was expanded 
 * [“My code is shit”: Negative automatic thoughts and outcomes of a behavioral experiment for code review anxiety](https://osf.io/preprints/psyarxiv/hz3et)
 * [Astro's Contribution Ladder](https://github.com/withastro/.github/blob/main/GOVERNANCE.md)
 * [Checklist for repository documentation](https://github.com/mntnr/audit-templates/blob/master/audit-template.md) by Maintainer Mountaineer
-* [LazyGit - a terminal UI for git commands](https://github.com/jesseduffield/lazygit?tab=readme-ov-file#features)
+* [LazyGit - a terminal UI for git commands](https://github.com/jesseduffield/lazygit?tab=readme-ov-file)
 
 ### README resources
 * [Drupal Guide to creating README.md](https://www.drupal.org/docs/develop/managing-a-drupalorg-theme-module-or-distribution-project/documenting-your-project/readmemd-template)
-* [README template from Reddit](https://github.com/Louis3797/awesome-readme-template?tab=readme-ov-file#gem-acknowledgements)
+* [README template from Reddit](https://github.com/Louis3797/awesome-readme-template?tab=readme-ov-file)
 * [Linux Foundation Beginner’s Guide to Open Source Software Development](https://training.linuxfoundation.org/training/beginners-guide-open-source-software-development)
 * [OctoGuide bot that helps contributors adhere to best practices for GitHub repositories](https://octo.guide/)
-* [A standard style for README files](https://github.com/RichardLitt/standard-readme/?tab=readme-ov-file#usage) by Richard Littauer
-* [Awesome README template](https://github.com/Louis3797/awesome-readme-template/blob/main/README-WITHOUT-EMOJI.md#prerequisites) by Louis3797
+* [A standard style for README files](https://github.com/RichardLitt/standard-readme/?tab=readme-ov-file) by Richard Littauer
+* [Awesome README template](https://github.com/Louis3797/awesome-readme-template/blob/main/README-WITHOUT-EMOJI.md) by Louis3797
 
 ## Contributors & Acknowledgement
 

--- a/create-template-documents-for-github-repositories.md
+++ b/create-template-documents-for-github-repositories.md
@@ -99,3 +99,4 @@ We started with a TL:DR about preparing for contributions but this was expanded 
 (in alphabetical order)
 * Ciara Flanagan, https://orcid.org/0009-0005-3153-7673
 * Laura Langdon (University of California Davis)
+* Richard Littauer, https://orcid.org/0000-0001-5428-7535

--- a/open-source-capstone-course.md
+++ b/open-source-capstone-course.md
@@ -143,8 +143,8 @@ Open Source with SLU, Saint Louis University
 - [Building Software Engineering Capacity through a University Open Source Program Office](https://dl.acm.org/doi/10.1145/3663529.3663866) Ekaterina Holdener; Daniel Shown
 
 ### Related Patterns
-- [Open Research Community Accelerator (ORCA)](https://github.com/CURIOSSorg/curioss-patterns/blob/main/summer-internship-program.md)
-- [Summer Internship Program](https://github.com/CURIOSSorg/curioss-patterns/blob/main/open-research-community-accelerator.md)
+- [Open Research Community Accelerator (ORCA)](./open-research-community-accelerator.md)
+- [Summer Internship Program](./summer-internship-program.md)
 
 ## Contributors & Acknowledgement
 

--- a/open-source-capstone-course.md
+++ b/open-source-capstone-course.md
@@ -151,5 +151,6 @@ Open Source with SLU, Saint Louis University
 - Ciara Flanagan, https://orcid.org/0009-0005-3153-7673
 - Daniel Shown (Saint Louis University), https://orcid.org/0009-0002-5716-8835
 - David Lippert (The George Washington University), https://orcid.org/0009-0003-6444-9595
+- Richard Littauer, https://orcid.org/0000-0001-5428-7535
 
 **A note on AI use:** In addition to working from Deep Dive transcripts, capturing learning from our community discussions and other patterns from our members, this pattern was drafted with the help of AI. As a small organization, tools like this help us turn rich conversations into written resources without losing the ideas along the way. As always, there were plenty of human eyes reviewing, editing and improving the content before this pattern made it to publication. Thanks go to our community for the insights. If you do spot any errors, please let us know so we can correct them!


### PR DESCRIPTION
There are a couple of things I do here: 

- Remove unnecessary link anchors. When linking to a different Markdown file or Webpage, any link which has a `#whatever` in it will go to the "whatever" heading on that document. In this PR, I remove a few of these links I (manually) found, which weren't necessary. It's almost always better to just include the plain link.
- Remove links like `https://github.com/CURIOSSorg/curioss-patterns/blob/main/open-research-community-accelerator.md`, and replace them with `./open-research-community-accelerator.md`. The first link will take people to this GitHub - the second, fixed link will take people to the rendered page on the Patterns website. We almost always want the second to happen, not the first. The `./` means "this file is in the same folder as this current file I am editing". 