### PR TITLE
Linted all files for Markdown issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,18 +11,19 @@ Thanks for wanting to contribute! Open a PR or an issue for anything.
 If you want to test the MkDocs site locally:
 
 1. **Install MkDocs Material** (requires Python):
+
    ```bash
    pip install -r .config/requirements.txt
    pip install mkdocs-material
    ```
 
 2. **Run the development server:**
+
    ```bash
    cd .config
    mkdocs serve
    ```
 
-3. **View the site:** Open your browser to http://127.0.0.1:8000
+3. **View the site:** Open your browser to <http://127.0.0.1:8000>
 
 The development server will automatically reload when you make changes to any markdown files.
-

--- a/Industry-and-community-expert-support-a-light-touch-volunteer-model.md
+++ b/Industry-and-community-expert-support-a-light-touch-volunteer-model.md
@@ -21,7 +21,7 @@ Engage experienced industry professionals and open source community experts as â
 
 - Education & Skills
 - Working with Tech Transfer / External Partners  
-   
+
 ## Context
 
 - A research or teaching university.
@@ -36,13 +36,14 @@ Engage experienced industry professionals and open source community experts as â
 
 ## Solution
 
-Establish a program that invites experienced technology professionals and open source community experts to participate as light-touch volunteers across OSPO programs and events. 
+Establish a program that invites experienced technology professionals and open source community experts to participate as light-touch volunteers across OSPO programs and events.
 
 The program should be designed to minimise the barrier to participation while maximizing the value that experts provide to students and the wider OSPO community.
 
 Key design considerations include:
 
 ### Minimum commitment expectations
+
 - Ask volunteers for a modest, flexible baseline commitment. Depending on the context, this could include:
 - Attending one or two events per semester
 - Supporting a hackathon
@@ -50,11 +51,11 @@ Key design considerations include:
 - Giving a talk
 - Answering questions in a shared communication workspace.
 
-Any engagement beyond this baseline is entirely at the volunteer's discretion. 
+Any engagement beyond this baseline is entirely at the volunteer's discretion.
 
 ### Formal but lightweight onboarding
 
-- Where possible, onboard volunteers formally, for example as contingent workers or university employees, even where no financial compensation is provided. 
+- Where possible, onboard volunteers formally, for example as contingent workers or university employees, even where no financial compensation is provided.
 
 - This confers a small number of meaningful soft perks such as a university email address, library access and/or access to co-working spaces.
 
@@ -62,12 +63,11 @@ Any engagement beyond this baseline is entirely at the volunteer's discretion.
 
 ### Integration into program communication infrastructure
 
-- Where a shared communication workspace exists (e.g. Slack), provide volunteers with access to relevant channels. 
+- Where a shared communication workspace exists (e.g. Slack), provide volunteers with access to relevant channels.
 
-- Public product or program channels allow volunteers to engage with individual teams or initiatives based on their interest and availability. 
+- Public product or program channels allow volunteers to engage with individual teams or initiatives based on their interest and availability.
 
 - Dedicated expert volunteer channels also allow the OSPO to share relevant information and coordinate engagement across the cohort as a whole.
-
 
 ## Resulting Context
 
@@ -103,7 +103,7 @@ Open Source with SLU, Saint Louis University
 
 ## Contributors & Acknowledgement
 
-- Ciara Flanagan (CURIOSS) https://orcid.org/0009-0005-3153-7673
-- Daniel Shown (Saint Louis University) https://orcid.org/0009-0002-5716-8835
+- Ciara Flanagan (CURIOSS) <https://orcid.org/0009-0005-3153-7673>
+- Daniel Shown (Saint Louis University) <https://orcid.org/0009-0002-5716-8835>
 
 A note on AI use: In addition to working from Deep Dive transcripts, capturing learning from our community discussions and other patterns from our members, this pattern was drafted with the help of AI. As a small organization, tools like this help us turn rich conversations into written resources without losing the ideas along the way. As always, there were plenty of human eyes reviewing, editing and improving the content before this pattern made it to publication. Thanks go to our community for the insights. If you do spot any errors, please let us know so we can correct them!

--- a/PATTERN-TEMPLATE.md
+++ b/PATTERN-TEMPLATE.md
@@ -46,12 +46,12 @@ Below is a list of common categories of academic OSPO activities \- please choos
 - Rewards & Recognition
 - Tools & Infrastructure
 - Working with Tech Transfer / External Partners  
-   
+
 ## Context
 
 *When and where does this pattern apply?*
 
-Describe the situation, prerequisites, and the context in which the problem arises. For example, is it applicable for all universities? 
+Describe the situation, prerequisites, and the context in which the problem arises. For example, is it applicable for all universities?
 
 ## Forces
 
@@ -74,8 +74,8 @@ Describe both the intended positive results and any potential side effects or co
 
 *Provide real-world instances of this pattern in action.*
 
-* Example 1: Description of a known use case.  
-* Example 2: Description of another instance.
+- Example 1: Description of a known use case.  
+- Example 2: Description of another instance.
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Introduction to the CURIOSS Patterns Practice
+
 A public repository for the CURIOSS Patterns Practice.
 
-For more information about patterns in general, please see the [About Patterns](#about-patterns) section below. 
+For more information about patterns in general, please see the [About Patterns](#about-patterns) section below.
 
 ## CURIOSS Patterns
 
-We have listed the CURIOSS Patterns by the common challenges or priorities of CURIOSS members. Patterns may be listed more than once if they relate to multiple themes. 
+We have listed the CURIOSS Patterns by the common challenges or priorities of CURIOSS members. Patterns may be listed more than once if they relate to multiple themes.
 <!-- material/tags -->
 <!-- material/tags -->
 
@@ -15,7 +16,7 @@ We have listed the CURIOSS Patterns by the common challenges or priorities of CU
 
 Patterns are reusable solutions to common problems within a specific context. Originating from architecture and urban design in the work of Christopher Alexander (see section on Origins), they were later adapted for software engineering, organizational design, and beyond. A pattern captures the essence of a proven solution in a way that can be applied flexibly to different scenarios, providing a shared language for understanding and resolving recurring challenges.
 
-Sharing knowledge is a key goal of the CURIOSS Community - we hope to build our CURIOSS Patterns Practice to record how we tackle the common problems facing OSPOs in university and research institutions. 
+Sharing knowledge is a key goal of the CURIOSS Community - we hope to build our CURIOSS Patterns Practice to record how we tackle the common problems facing OSPOs in university and research institutions.
 
 The CURIOSS Patterns Practice is based on the [InnerSource Commons Patterns Practice](https://github.com/InnerSourceCommons/InnerSourcePatterns/) and we would like to thank all those in that community for inspiring us in this effort.
 
@@ -29,11 +30,11 @@ The CURIOSS Patterns Practice is based on the [InnerSource Commons Patterns Prac
 For CURIOSS Patterns we also include:
 
 * **Title**: A phrase that helps identify the pattern.  
-* **Theme/Cateogry**: To help us categorize our patterns. 
+* **Theme/Cateogry**: To help us categorize our patterns.
 * **Known Instances**: Information about who has used the pattern.
 * **Contributors**: A list of all those who contributed to the creation of the pattern (inside and outside of GitHub).
 
-In some cases, we have even included some personal inspiration from the pattern authors. 
+In some cases, we have even included some personal inspiration from the pattern authors.
 
 ### Benefits of Patterns
 
@@ -74,7 +75,7 @@ The concept of design patterns originated in the field of architecture. Christop
 
 Alexander’s approach to patterns was revolutionary because it provided a structured method for solving design problems. His patterns were not rigid blueprints but flexible guidelines that could be adapted to specific situations. This adaptability made them highly valuable in architecture and laid the groundwork for their application in other fields.[^1]
 
-[^1]: ‘History and Evolution of Design Patterns: From Architecture to Software’, Design Patterns. Accessed: Dec. 12, 2024. [Online]. Available: https://softwarepatternslexicon.com
+[^1]: ‘History and Evolution of Design Patterns: From Architecture to Software’, Design Patterns. Accessed: Dec. 12, 2024. [Online]. Available: <https://softwarepatternslexicon.com>
 
 ## Contributing
 
@@ -82,4 +83,4 @@ Thanks for wanting to contribute. Please take a look at our brief [Contributing 
 
 ## License
 
-All work here is licensed under a CC-BY 4.0 International License (https://creativecommons.org/licenses/by/4.0/deed.en), by the CURIOSS organizers and contributors.
+All work here is licensed under a CC-BY 4.0 International License (<https://creativecommons.org/licenses/by/4.0/deed.en>), by the CURIOSS organizers and contributors.

--- a/cohosting-student-events.md
+++ b/cohosting-student-events.md
@@ -12,21 +12,19 @@ Collaborate with student clubs to co-host one-off, open source-focused campus ev
 
 ## Problem / Challenge
 
-There is a growing interest in open source amongst student cohorts outside of academic courses. 
+There is a growing interest in open source amongst student cohorts outside of academic courses.
 
-However, OSPO staff time and resources are limited. 
-
+However, OSPO staff time and resources are limited.
 
 ## Pattern Category
 
-* Community building   
+* Community building
 * Developing and sharing best practices  
 * OSS education & skills  
 
 ## Context
 
 A university wishes to broaden open source engagement with students, particularly in terms of skills development and growing a culture of contribution.
- 
 
 ## Forces
 
@@ -58,26 +56,25 @@ Division of tasks may typically be:
 * Supporting the setup of the event, welcoming attendees, facilitating technical activities, and clean-up post event.
 * Amplifying the impact of the event through social media/mailing lists.
 
-
 ## Resulting Context
 
-OSPO staff gain valuable insights into the open source-related resources that students want on campus. 
+OSPO staff gain valuable insights into the open source-related resources that students want on campus.
 
 Student leaders feel empowered by the opportunity to drive an event’s focus and to deliver it. (They also can add the event to their resumes.)
 
 Both OSPO staff and student organizations build their networks and grow their mailing lists (through event registrations).
 
-The process of event organization facilitates relationship building between the OSPO and student clubs/organizations. 
+The process of event organization facilitates relationship building between the OSPO and student clubs/organizations.
 
-One-off events can be used as starting points for further collaboration. Examples include: 
+One-off events can be used as starting points for further collaboration. Examples include:
 
 * Cultivating interest in full-term academic courses.
-* Encouraging students to apply to mentorship/internship opportunities. 
+* Encouraging students to apply to mentorship/internship opportunities.
 * Recruiting students as contributors to campus open source projects.
 
 ### Additional Learning from University of California Santa Cruz
 
-Students have a lot of priorities competing for their time and attention. When co-organizing an event, it’s helpful to ensure regular check-ins and/or set deadlines for reserving rooms, advertising, etc. 
+Students have a lot of priorities competing for their time and attention. When co-organizing an event, it’s helpful to ensure regular check-ins and/or set deadlines for reserving rooms, advertising, etc.
 
 Student co-hosts who don’t have explicit open source experience may benefit from a crash course on using Git/GitHub or other relevant topics.
 
@@ -85,7 +82,7 @@ Industry partners may be able to donate swag or small pots of money. This streng
 
 ### Additional Learning from George Washington University
 
-When OSPOs are able to provide space, food, spot prizes, or volunteering time, these contributions can go a long way to helping an event succeed and will strengthen connections with student organizations. 
+When OSPOs are able to provide space, food, spot prizes, or volunteering time, these contributions can go a long way to helping an event succeed and will strengthen connections with student organizations.
 
 Events like hackathons are great opportunities to teach students about open source, community building, how to code collaboratively using git, and more.  Plus, government and industry partners can be invited to scope work and act as mentors and judges all of which can lead to stronger connections between students and open source community leaders.
 
@@ -108,6 +105,7 @@ We also hosted a one-day bootcamp for a GW open source data science project call
 * [GWU George Hacks - 2025 Innovation Hackathon](https://georgehacks.org)
 
 ### Related Patterns
+
 * [Facilitate connections at Open Source Conferences](./facilitate-connections-at-open-source-conferences.md)
 * [Host an Open Source Conference](./host-an-open-source-conference.md)
 * [Informal OSPO focus group sessions at Open Source Events](./informal-ospo-focus-groups-at-open-source-events.md)
@@ -118,8 +116,8 @@ We also hosted a one-day bootcamp for a GW open source data science project call
 
 ## Contributors & Acknowledgement
 
-* Emily Lovell, University of California Santa Cruz, https://orcid.org/0000-0001-5531-5956
-* Stephanie Lieggi, University of California Santa Cruz, https://orcid.org/0009-0000-5647-6540
-* Yelena Martynovskaya, University of California Santa Cruz 
-* Ciara Flanagan, https://orcid.org/0009-0005-3153-7673
+* Emily Lovell, University of California Santa Cruz, <https://orcid.org/0000-0001-5531-5956>
+* Stephanie Lieggi, University of California Santa Cruz, <https://orcid.org/0009-0000-5647-6540>
+* Yelena Martynovskaya, University of California Santa Cruz
+* Ciara Flanagan, <https://orcid.org/0009-0005-3153-7673>
 * David Lippert, George Washington University, [https://orcid.org/0009-0003-6444-9595](https://orcid.org/0009-0003-6444-9595)

--- a/collaborate-with-external-partners-on-open-source-hackathons.md
+++ b/collaborate-with-external-partners-on-open-source-hackathons.md
@@ -8,9 +8,11 @@ tags:
 # Collaborate with External Partners on Open Source Hackathons
 
 ## Pattern Summary
+
 Create a process for ensuring that partner contributions are purposeful and that roles and responsibilities are clearly defined in advance.
 
 ## Problem / Challenge
+
 Hackathons that involve external partners (e.g. companies, nonprofits, or other organizations) can deliver significant value for participants. However, they introduce coordination and project management challenges that are easy to underestimate.
 
 External partners vary widely in their level of hackathon experience and may have unrealistic expectations relating to decision making, event management and structure of the hackathon.
@@ -20,21 +22,24 @@ A lack of early engagement and role clarity can lead to ambiguity about who is t
 Partner contributions that are poorly integrated into the event reduce the value for participants.
 
 ## Pattern Category
+
 - Community Building
 - Education & Skills
 - Promoting Best Practices
 - Working with Tech Transfer / External Partners  
-   
+
 ## Context
+
 A university OSPO is involved in organizing or co-organizing a hackathon.
 
-One or more external organizations have expressed interest in participating as sponsors, problem-statement providers or resource contributors. 
+One or more external organizations have expressed interest in participating as sponsors, problem-statement providers or resource contributors.
 
-Internal stakeholders from across the institution are also involved. 
+Internal stakeholders from across the institution are also involved.
 
 The OSPO has established relationships with both external partners and relevant internal groups.
 
 ## Forces
+
 External partners may not know what a productive hackathon contribution looks like or may arrive with a highly structured approach that does not fit the university context.
 
 Partners with well-developed playbooks can be a significant asset but their approach may need negotiation and adaptation to work well for student participants.
@@ -46,64 +51,73 @@ The OSPO has a coordinating role but not a directive one. It must build shared u
 Logistics and role clarity are significantly harder to address on the day itself, when time pressure is high.
 
 ## Solution
+
 Obtain clarity on roles and logistics by positioning the OSPO as the central coordination point through which external partners, faculty and student groups can each contribute to the event.
 
 The solution below outlines some core activities to consider:
 
 ### Define the partner's programmatic contribution
-Before engaging with logistics, work with external partners to establish what they are uniquely positioned to offer. Questions to ask include: 
 
-- What access or resources does the partner bring that participants would not otherwise have e.g. proprietary tools, specialized datasets, on-call subject-matter engineers, mentors, prizes? 
-- What real-world problem statement can the partner offer? 
+Before engaging with logistics, work with external partners to establish what they are uniquely positioned to offer. Questions to ask include:
+
+- What access or resources does the partner bring that participants would not otherwise have e.g. proprietary tools, specialized datasets, on-call subject-matter engineers, mentors, prizes?
+- What real-world problem statement can the partner offer?
 
 ### Negotiate the partner's facilitation role
-- Assess whether the partner has an established facilitation playbook and, if so, how well it fits the university context and participant needs. 
-- Where a partner has a well-tested approach, work to integrate it into the event structure. 
+
+- Assess whether the partner has an established facilitation playbook and, if so, how well it fits the university context and participant needs.
+- Where a partner has a well-tested approach, work to integrate it into the event structure.
 - Where a partner has no established approach, provide more scaffolding and take a more active role in defining what their participation looks like.
 
-Partners with highly structured playbooks may require ongoing negotiation to ensure their approach serves participants rather than primarily showcasing the partner organization. 
+Partners with highly structured playbooks may require ongoing negotiation to ensure their approach serves participants rather than primarily showcasing the partner organization.
 
 Problem statements that are too narrow or proprietary can constrain participant creativity — this tension is best surfaced early in planning.
 
 ### Manage expectations and clarify roles
-- Meet external stakeholders in advance to agree on the event structure and individual responsibilities. 
+
+- Meet external stakeholders in advance to agree on the event structure and individual responsibilities.
 - Produce a shared run-of-show document before the event that sets out the event timeline and key phases (opening, hacking period, mentorship windows, judging, closing). The run-of-show document is only effective if all parties engage with it before the event. Securing that engagement requires active follow-through from the OSPO.
-- Outline the specific expectations for each role i.e. mentors, judges, volunteers and partner representatives - including who owns each phase and each category of decision. 
+- Outline the specific expectations for each role i.e. mentors, judges, volunteers and partner representatives - including who owns each phase and each category of decision.
 - Circulate this document to all parties with enough lead time to resolve any disagreements before the day of the event.
 - Communicate partner contributions to internal stakeholders and participants so they can prepare to make use of it.
 
 ## Resulting Context
-Collaborating with external partners offers participants fresh opportunities to access additional resources, new tools and real-world problems in a hackathon. 
+
+Collaborating with external partners offers participants fresh opportunities to access additional resources, new tools and real-world problems in a hackathon.
 
 Role clarity achieved before the hackathon significantly reduces workload and coordination overhead in the run-up to the event and on the day itself.
 
-External partners feel their contribution is purposeful and well-integrated, strengthening the relationship for future collaboration. 
+External partners feel their contribution is purposeful and well-integrated, strengthening the relationship for future collaboration.
 
-The OSPO reinforces its value as a neutral convener and steward of open source activities on campus. 
+The OSPO reinforces its value as a neutral convener and steward of open source activities on campus.
 
 ### Additional learning from UCSC OSPO, University of California, Santa Cruz
-It’s critical to be really clear ahead of time on roles and ‘who owns what’. 
 
-Details such as the flow of the event, expectations for mentors, volunteers and judges needs to be agreed upon and finalised in advance. 
+It’s critical to be really clear ahead of time on roles and ‘who owns what’.
 
-It’s also important to clarify *how* each phase will be run. 
+Details such as the flow of the event, expectations for mentors, volunteers and judges needs to be agreed upon and finalised in advance.
+
+It’s also important to clarify *how* each phase will be run.
 
 ### Additional learning from the Carnegie Mellon University OSPO
-There are two big programmatic advantages to having partners. 
 
-Firstly, they provide access to something that we might not have on campus. We partnered with one organization that donated expensive tooling for the event and also supplied engineers who were on call to answer questions. 
+There are two big programmatic advantages to having partners.
+
+Firstly, they provide access to something that we might not have on campus. We partnered with one organization that donated expensive tooling for the event and also supplied engineers who were on call to answer questions.
 
 Secondly, external partners define problem statements using real-world problems.
 
 Often, our role as the OSPO, is to act as a central point that enables faculty, students or external stakeholders to organize the hackathon and have an equitable voice.
 
 ## Known Instances
+
 - [CMU Open Source Program Office](https://www.library.cmu.edu/services/ospo), CMU Libraries, Carnegie Mellon University
 - [UCSC OSPO](https://ucsc-ospo.github.io/). University of California, Santa Cruz
 
 ## References
 
 ### Related Patterns
+
 - [Organise an Open Source Hackathon](organize-an-open-source-hackathon.md)
 - [Design a Collaborative Open Source Hackathon](design-a-collaborative-open-source-hackathon.md)
 - [Embed wellbeing into Student Hackathons](embed-wellbeing-into-student-hackathons.md)
@@ -112,9 +126,10 @@ Often, our role as the OSPO, is to act as a central point that enables faculty, 
 - [Lower the barriers to entry for Student Hackathons](lower-the-barriers-to-entry-for-student-hackathons.md)
 
 ## Contributors & Acknowledgement
+
 - Angela Newell, University of Texas at Austin
-- Ciara Flanagan, https://orcid.org/0009-0005-3153-7673
-- David Lippert, George Washington University, https://orcid.org/0009-0003-6444-9595
-- Emily Lovell, University of California Santa Cruz, https://orcid.org/0000-0001-5531-5956
+- Ciara Flanagan, <https://orcid.org/0009-0005-3153-7673>
+- David Lippert, George Washington University, <https://orcid.org/0009-0003-6444-9595>
+- Emily Lovell, University of California Santa Cruz, <https://orcid.org/0000-0001-5531-5956>
 - Laura Langdon, University of California, Davis
-- Tom Hughes, Carnegie Mellon University, https://orcid.org/0009-0008-7516-3687
+- Tom Hughes, Carnegie Mellon University, <https://orcid.org/0009-0008-7516-3687>

--- a/create-a-donor-or-sponsorship-prospectus.md
+++ b/create-a-donor-or-sponsorship-prospectus.md
@@ -7,9 +7,11 @@ tags:
 # Create a Donor/Sponsorship Prospectus
 
 ## Pattern Summary
+
 Create and publish a donor/sponsorship prospectus that articulates the opportunities, benefits and impact of financial supporting the OSPO and its activities.
 
 ## Problem / Challenge
+
 Academic OSPOs are emerging entities within academia that typically depend on short-term grant funding rather than stable institutional budgets.
 
 Unlike traditional university fundraising that often relies on alumni networks and established development offices, OSPOs need to attract support from technology companies, open source foundations, individual developers and other non-traditional academic supporters who may have varying levels of familiarity with university partnership processes.
@@ -17,11 +19,13 @@ Unlike traditional university fundraising that often relies on alumni networks a
 Academic OSPOs may struggle to articulate the benefits of giving to potential donors or sponsors.
 
 ## Pattern Category
+
 - Community Building
 - Demonstrating Value as an Academic OSPO
 - Funding & Financial Support
-   
+
 ## Context
+
 A research university creating large volumes of research outputs across every discipline.
 
 An OSPO has been established.
@@ -29,65 +33,77 @@ An OSPO has been established.
 A stable budget line for the OSPO and/or open source initiatives may not be established within the institution.
 
 ## Forces
+
 Potential donors and sponsors may not know how to donate directly to the OSPO.
 
 Procurement and payment guidelines allow for once-off or flexible donations directly to the OSPO.
 
-Donation protocols and payment methods have already been confirmed and agreed with finance colleagues. 
+Donation protocols and payment methods have already been confirmed and agreed with finance colleagues.
 
 ## Solution
-Develop and publish a comprehensive donor/sponsorship prospectus that serves as both a marketing tool and an information resource. 
+
+Develop and publish a comprehensive donor/sponsorship prospectus that serves as both a marketing tool and an information resource.
 
 The solution below outlines different types of information that may be included in the document:
 
 ### Context and Background
-* Brief explanation of OSPO mission and activities.
-* Information about the academic institution and its open source commitment.
+
+- Brief explanation of OSPO mission and activities.
+- Information about the academic institution and its open source commitment.
 
 ### Tiered Sponsorship Levels
-* Defined sponsorship tiers (e.g., Community, Bronze, Silver, Gold, Platinum) with specific funding amounts.
-* The benefits for each sponsorship tier may include recognition, networking opportunities and promotion opportunities.
+
+- Defined sponsorship tiers (e.g., Community, Bronze, Silver, Gold, Platinum) with specific funding amounts.
+- The benefits for each sponsorship tier may include recognition, networking opportunities and promotion opportunities.
 
 ### Value Proposition
+
 Every OSPO is unique. Some common benefits to funding OSPOs may include:
-* Access to emerging talent, research insights and innovation pipelines.
-* Impact through metrics, case studies and success stories.
+
+- Access to emerging talent, research insights and innovation pipelines.
+- Impact through metrics, case studies and success stories.
 
 ### Varied Funding Options (where possible)
-* General operational support for ongoing OSPO activities.
-* Event-specific sponsorships for workshops and conferences.
-* Project-based funding for specific research or infrastructure initiatives.
-* In-kind contributions for services, software or expertise.
+
+- General operational support for ongoing OSPO activities.
+- Event-specific sponsorships for workshops and conferences.
+- Project-based funding for specific research or infrastructure initiatives.
+- In-kind contributions for services, software or expertise.
 
 ### Practical Information
-* Payment methods and financial processing details.
-* Clear contact information.
-* Next steps for interested sponsors
 
-Ideally, the sponsorship prospectus should include high quality design with easy to understand graphics. 
+- Payment methods and financial processing details.
+- Clear contact information.
+- Next steps for interested sponsors
+
+Ideally, the sponsorship prospectus should include high quality design with easy to understand graphics.
 
 It should also be easily accessible with prominent placement on the OSPO website, clear navigation and a downloadable PDF version.
 
 ## Resulting Context
+
 A donor/sponsorship prospectus provides clear information and enables potential supporters to self-identify opportunities that align with their interests and their available resources.
 
 ## Known Instances
-* [The GW Open Source Program Office](https://ospo.gwu.edu/), The George Washington University
-* [UC Santa Cruz OSPO](https://ucsc-ospo.github.io/), University of California Santa Cruz, [UC OSPO Network](https://ucospo.net)  
+
+- [The GW Open Source Program Office](https://ospo.gwu.edu/), The George Washington University
+- [UC Santa Cruz OSPO](https://ucsc-ospo.github.io/), University of California Santa Cruz, [UC OSPO Network](https://ucospo.net)  
 
 ## References
-* [UC Open Source Research Symposium 2024 Sponsorship Prospectus](https://drive.google.com/file/d/1cgxd-DRan9hC1JV2zefeHuXqWZpcRAsf/view)
-* [Sponsor Prospectus for GW OSCON 2025](https://gwu.box.com/s/t85385ljfie6ixtt0zxx2mnw6nxh40mx)
-* [University of Santa Cruz OSPO giving page](https://ucsc-ospo.github.io/bankinfo/)
+
+- [UC Open Source Research Symposium 2024 Sponsorship Prospectus](https://drive.google.com/file/d/1cgxd-DRan9hC1JV2zefeHuXqWZpcRAsf/view)
+- [Sponsor Prospectus for GW OSCON 2025](https://gwu.box.com/s/t85385ljfie6ixtt0zxx2mnw6nxh40mx)
+- [University of Santa Cruz OSPO giving page](https://ucsc-ospo.github.io/bankinfo/)
 
 ### Related Patterns
-* [Secure sponsorship for an Open Source Conference](./secure-sponsorship-for-an-open-source-conference.md)
-* [Set up an OSPO Giving Page](./set-up-an-ospo-giving-page.md)
+
+- [Secure sponsorship for an Open Source Conference](./secure-sponsorship-for-an-open-source-conference.md)
+- [Set up an OSPO Giving Page](./set-up-an-ospo-giving-page.md)
 
 ## Contributors & Acknowledgement
+
 In alphabetical order
 
-* Ciara Flanagan, https://orcid.org/0009-0005-3153-7673
-* David Lippert, The George Washington University, https://orcid.org/0009-0003-6444-9595
-* Stephanie Lieggi, University of California Santa Cruz, https://orcid.org/0009-0000-5647-6540
-
+- Ciara Flanagan, <https://orcid.org/0009-0005-3153-7673>
+- David Lippert, The George Washington University, <https://orcid.org/0009-0003-6444-9595>
+- Stephanie Lieggi, University of California Santa Cruz, <https://orcid.org/0009-0000-5647-6540>

--- a/create-template-documents-for-github-repositories.md
+++ b/create-template-documents-for-github-repositories.md
@@ -28,7 +28,7 @@ Student and research repositories are missing the crucial documentation required
 
 ## Forces
 
-Labs and projects have expertise in computer science and coding. However, practitioners lack the knowledge and/or confidence to build the OSS communities needed to sustain their projects. 
+Labs and projects have expertise in computer science and coding. However, practitioners lack the knowledge and/or confidence to build the OSS communities needed to sustain their projects.
 
 Researchers and development teams on open science/open source projects are already overburdened.
 
@@ -36,7 +36,7 @@ Researchers and development teams on open science/open source projects are alrea
 
 ### Needs Analysis
 
-Review what documentation is (or isn't) in place on a sample of repositories. 
+Review what documentation is (or isn't) in place on a sample of repositories.
 
 Talk to a sample of students/researchers who are not using documentation to find out more. Important questions to ask relate to perceived challenges of writing documentation and their satisfaction levels with contributions to date.
 
@@ -73,30 +73,32 @@ We started with a TL:DR about preparing for contributions but this was expanded 
 
 ## Known Instances
 
-* [UC Davis OSPO](https://ucospo.net/davis/), University of California Davis, [UC OSPO Network](https://ucospo.net)  
+- [UC Davis OSPO](https://ucospo.net/davis/), University of California Davis, [UC OSPO Network](https://ucospo.net)  
 
 ## References
 
-* [Growing a Community Around a Project](https://ucospo.net/oss-resources/) - TL:DR from the UC OSPO network about preparing for contributions
-* [How to make reviewing pull requests a better experience](https://opensource.net/simplify-pull-request-reviews/) from OpenSource.net
-* [OpenSauced's guide to becoming a maintainer](https://opensauced.pizza/learn/becoming-a-maintainer)
-* [Solving the Maker-Taker problem](https://dri.es/solving-the-maker-taker-problem) by Dries Buytaert
-* [“My code is shit”: Negative automatic thoughts and outcomes of a behavioral experiment for code review anxiety](https://osf.io/preprints/psyarxiv/hz3et)
-* [Astro's Contribution Ladder](https://github.com/withastro/.github/blob/main/GOVERNANCE.md)
-* [Checklist for repository documentation](https://github.com/mntnr/audit-templates/blob/master/audit-template.md) by Maintainer Mountaineer
-* [LazyGit - a terminal UI for git commands](https://github.com/jesseduffield/lazygit?tab=readme-ov-file)
+- [Growing a Community Around a Project](https://ucospo.net/oss-resources/) - TL:DR from the UC OSPO network about preparing for contributions
+- [How to make reviewing pull requests a better experience](https://opensource.net/simplify-pull-request-reviews/) from OpenSource.net
+- [OpenSauced's guide to becoming a maintainer](https://opensauced.pizza/learn/becoming-a-maintainer)
+- [Solving the Maker-Taker problem](https://dri.es/solving-the-maker-taker-problem) by Dries Buytaert
+- [“My code is shit”: Negative automatic thoughts and outcomes of a behavioral experiment for code review anxiety](https://osf.io/preprints/psyarxiv/hz3et)
+- [Astro's Contribution Ladder](https://github.com/withastro/.github/blob/main/GOVERNANCE.md)
+- [Checklist for repository documentation](https://github.com/mntnr/audit-templates/blob/master/audit-template.md) by Maintainer Mountaineer
+- [LazyGit - a terminal UI for git commands](https://github.com/jesseduffield/lazygit?tab=readme-ov-file)
 
 ### README resources
-* [Drupal Guide to creating README.md](https://www.drupal.org/docs/develop/managing-a-drupalorg-theme-module-or-distribution-project/documenting-your-project/readmemd-template)
-* [README template from Reddit](https://github.com/Louis3797/awesome-readme-template?tab=readme-ov-file)
-* [Linux Foundation Beginner’s Guide to Open Source Software Development](https://training.linuxfoundation.org/training/beginners-guide-open-source-software-development)
-* [OctoGuide bot that helps contributors adhere to best practices for GitHub repositories](https://octo.guide/)
-* [A standard style for README files](https://github.com/RichardLitt/standard-readme/?tab=readme-ov-file) by Richard Littauer
-* [Awesome README template](https://github.com/Louis3797/awesome-readme-template/blob/main/README-WITHOUT-EMOJI.md) by Louis3797
+
+- [Drupal Guide to creating README.md](https://www.drupal.org/docs/develop/managing-a-drupalorg-theme-module-or-distribution-project/documenting-your-project/readmemd-template)
+- [README template from Reddit](https://github.com/Louis3797/awesome-readme-template?tab=readme-ov-file)
+- [Linux Foundation Beginner’s Guide to Open Source Software Development](https://training.linuxfoundation.org/training/beginners-guide-open-source-software-development)
+- [OctoGuide bot that helps contributors adhere to best practices for GitHub repositories](https://octo.guide/)
+- [A standard style for README files](https://github.com/RichardLitt/standard-readme/?tab=readme-ov-file) by Richard Littauer
+- [Awesome README template](https://github.com/Louis3797/awesome-readme-template/blob/main/README-WITHOUT-EMOJI.md) by Louis3797
 
 ## Contributors & Acknowledgement
 
 (in alphabetical order)
-* Ciara Flanagan, https://orcid.org/0009-0005-3153-7673
-* Laura Langdon (University of California Davis)
-* Richard Littauer, https://orcid.org/0000-0001-5428-7535
+
+- Ciara Flanagan, <https://orcid.org/0009-0005-3153-7673>
+- Laura Langdon (University of California Davis)
+- Richard Littauer, <https://orcid.org/0000-0001-5428-7535>

--- a/design-a-collaborative-open-source-hackathon.md
+++ b/design-a-collaborative-open-source-hackathon.md
@@ -9,94 +9,110 @@ tags:
 # Design a Collaborative Open Source Hackathon
 
 ## Pattern Summary
-Design university hackathons as collaborative learning experiences rather than as competitive events. 
+
+Design university hackathons as collaborative learning experiences rather than as competitive events.
 
 ## Problem / Challenge
-Traditional competitive hackathons at universities may create barriers to entry and participation. The competitive format typically values finished products, technical complexity and speed. 
+
+Traditional competitive hackathons at universities may create barriers to entry and participation. The competitive format typically values finished products, technical complexity and speed.
 
 The competitive atmosphere may deter women; underrepresented minorities in tech; and students who are new to programming and open source from participating in the events.
 
 The focus on winning can also discourage experimentation and limit knowledge sharing. Winning teams often produce impressive prototypes that are abandoned after the event.
 
 ## Pattern Category
+
 - Community Building
 - Diversity, Equity, Inclusion
 - Education & Skills
 - Rewards & Recognition
 - Tools & Infrastructure
 - Working with Tech Transfer / External Partners  
-   
+
 ## Context
-A research institution or a university. 
+
+A research institution or a university.
 
 An OSPO has been established.
 
-The OSPO is organizing an open source hackathon. 
+The OSPO is organizing an open source hackathon.
 
 ## Forces
-There is flexibility to negotiate on prizes or competitive elements with partners or external sponsors. 
+
+There is flexibility to negotiate on prizes or competitive elements with partners or external sponsors.
 
 ## Solution
+
 Build in some or all of the actions below to reframe a hackathon as a collaborative experience rather than a competition.
 
 ### Remove competitive elements
-Cash prizes create a more competitive atmosphere. Where possible, offer universal participation prizes for all in the form of gift cards. 
+
+Cash prizes create a more competitive atmosphere. Where possible, offer universal participation prizes for all in the form of gift cards.
 
 Prize categories should emphasise good practice and skills development rather than outputs (e.g. best use of open source, best research advancement).
 
 ### Value good open source practices
-Provide recognition for meaningful open source work including design, documentation, testing, community building and accessibility improvements - not just code. 
 
-Make this explicit in the hackathon’s code of conduct and in decisions around rewards and celebrating contributions. 
+Provide recognition for meaningful open source work including design, documentation, testing, community building and accessibility improvements - not just code.
+
+Make this explicit in the hackathon’s code of conduct and in decisions around rewards and celebrating contributions.
 
 ### Create an intentional welcoming environment
-Establish a clear code of conduct that promotes collaboration and support amongst and between teams. 
+
+Establish a clear code of conduct that promotes collaboration and support amongst and between teams.
 
 Brief mentors on expectations in relation to supporting students; and celebrating learning, skills development and collaboration over outputs.
 
 ### Work with existing open source projects (where possible)
-Use the hackathon theme to source research and open source projects on campus that would benefit from a hackathon’s input. 
+
+Use the hackathon theme to source research and open source projects on campus that would benefit from a hackathon’s input.
 
 ### Provide scaffolding for all skill levels
+
 Offer introductory workshops to students who are new to open source.
 
-Provide a range of contribution opportunities from beginner-friendly issues (documentation, simple bug fixes) to advanced challenges. 
+Provide a range of contribution opportunities from beginner-friendly issues (documentation, simple bug fixes) to advanced challenges.
 
 Ensure that project maintainers label issues appropriately in advance and where possible, that they are present to provide support.
 
 ## Resulting Context
-Students who may be intimidated by competitive hackathons feel welcome to participate and experiment. 
 
-Hackathon participation becomes more diverse as the collaborative model appeals to students who value learning, community and meaningful impact over competition. 
+Students who may be intimidated by competitive hackathons feel welcome to participate and experiment.
 
-Beginners gain confidence through successful contributions and supportive environments. 
+Hackathon participation becomes more diverse as the collaborative model appeals to students who value learning, community and meaningful impact over competition.
+
+Beginners gain confidence through successful contributions and supportive environments.
 
 Students develop not just technical skills but also collaboration, communication and community engagement skills essential for open source work.
 
-Researchers and open source projects gain access to a pipeline of potential new contributors/maintainers. 
+Researchers and open source projects gain access to a pipeline of potential new contributors/maintainers.
 
 ### Additional Learning from the UC OSPO Network
+
 There are different models for non-competitive hackathons.
 
 One example is setting the same challenge for everyone and regrouping the following day to either combine solutions or work collaboratively on a ‘whole group’ solution.
 
-We offered an alternative to a cash prize where the sponsor provided mentorship for a winning team. 
+We offered an alternative to a cash prize where the sponsor provided mentorship for a winning team.
 
 ### Additional Learning from Carnegie Mellon University OSPO
+
 Cash prizes do change the dynamics of hackathons. Sponsorship doesn’t have to focus on prizes. Sometimes, we partner with sponsors to provide specific technologies during the hackathon. In this case, students get the opportunity to experiment new tools or platforms at no expense.
 
 We also tried hackathon models where multiple groups tackle a common problem and we explore the solution generated rather than focus on a final judgement and award.
 
 ### Additional learning from the University of Texas OSPO
+
 We encourage participants with multiple skill levels. We deliver pre-training workshops on GitHub, Jupyter Notebook and Python for students who are new or less familiar with open source. This gives them a chance to upskill in advance of the hackathon.
 
 Every team has a mentor and we provide mentor training beforehand.
 
-We also host ‘pop-in’ presentations three times a day to keep people on track and make sure everybody's okay. 
+We also host ‘pop-in’ presentations three times a day to keep people on track and make sure everybody's okay.
 
 We’ve found that collaborative open source hackathons tend to attract more women than competitive hackathons.
 
 ## Known Instances
+
 - [CMU Open Source Program Office](https://www.library.cmu.edu/services/ospo), CMU Libraries, Carnegie Mellon University
 - [University of California OSPO Network](https://ucospo.net/)
 - [UCSC OSPO](https://ucsc-ospo.github.io/). University of California, Santa Cruz
@@ -105,6 +121,7 @@ We’ve found that collaborative open source hackathons tend to attract more wom
 ## References
 
 ### Related Patterns
+
 - [Organize an Open Source Hackathon](organize-an-open-source-hackathon.md)
 - [Enable Student-led Hackathons](enable-student-led-hackathons.md)
 - [Embed wellbeing into Student Hackathons](embed-wellbeing-into-student-hackathons.md)
@@ -113,10 +130,11 @@ We’ve found that collaborative open source hackathons tend to attract more wom
 - [Lower the barriers to entry for Student Hackathons](lower-the-barriers-to-entry-for-student-hackathons.md)
 
 ## Contributors & Acknowledgement
+
 - Angela Newell, University of Texas at Austin
-- Ciara Flanagan, https://orcid.org/0009-0005-3153-7673
-- David Lippert, George Washington University, https://orcid.org/0009-0003-6444-9595
-- Emily Lovell, University of California Santa Cruz, https://orcid.org/0000-0001-5531-5956
+- Ciara Flanagan, <https://orcid.org/0009-0005-3153-7673>
+- David Lippert, George Washington University, <https://orcid.org/0009-0003-6444-9595>
+- Emily Lovell, University of California Santa Cruz, <https://orcid.org/0000-0001-5531-5956>
 - Laura Langdon, University of California, Davis
-- Tom Hughes, Carnegie Mellon University, https://orcid.org/0009-0008-7516-3687
+- Tom Hughes, Carnegie Mellon University, <https://orcid.org/0009-0008-7516-3687>
   

--- a/embed-wellbeing-into-student-hackathons.md
+++ b/embed-wellbeing-into-student-hackathons.md
@@ -7,69 +7,82 @@ tags:
 # Embed wellbeing into Student Hackathons
 
 ## Pattern Summary
+
 Embed physical and psychological wellbeing into student hackathons to ensure that participants can perform at their best while remaining safe and supported throughout the event.
 
 ## Problem / Challenge
-Hackathon culture tends to glorify extreme effort at the expense of basic self-care. 
+
+Hackathon culture tends to glorify extreme effort at the expense of basic self-care.
 
 While mentors bring valuable expertise, some may unintentionally undermine wellbeing norms if not given clear guidance.
 
 Left unaddressed, this can lead to physical exhaustion, impaired decision-making, and safety incidents — particularly for younger or more vulnerable participants.
 
 ## Pattern Category
+
 - Community Building
 - Education & Skills
 - Promoting Best Practices
-   
+
 ## Context
-A university or research institution. 
+
+A university or research institution.
 
 An OSPO has been established.
 
 The OSPO is involved in organizing or supporting a hackathon.
 
 ## Forces
+
 The hackathon will take place over a 24 or 48 hour period.
 
-Hackathon participants may be on-site overnight. 
+Hackathon participants may be on-site overnight.
 
-Student teams may be unsupervised for periods of time. 
+Student teams may be unsupervised for periods of time.
 
 Mentors will also be on-site for guidance.
 
 A budget is available for food and hydration.
 
 ## Solution
+
 Design wellbeing and safety into the following areas:
 
 ### Planning
+
 Organizers should establish clear positions on sleep, participant welfare and safety.
 
-Sleeping should be a non-negotiable requirement for participation. 
+Sleeping should be a non-negotiable requirement for participation.
 
 ### Mentor Training
-Provide clear guidance to mentors on the hackathon’s approach to wellbeing. 
+
+Provide clear guidance to mentors on the hackathon’s approach to wellbeing.
 
 Brief mentors explicitly on safety guidelines and actively encouraging participants to sleep.
 
 ### Food and Hydration
-Ensure that food, snacks and water are available on-site throughout the event — particularly at night. This removes the need for participants to leave the venue alone at night, which presents both safety and safeguarding risks. 
+
+Ensure that food, snacks and water are available on-site throughout the event — particularly at night. This removes the need for participants to leave the venue alone at night, which presents both safety and safeguarding risks.
 
 ### Minors
-Where participation from minors is permitted, coordinate with campus risk management colleagues. 
+
+Where participation from minors is permitted, coordinate with campus risk management colleagues.
 
 Areas for consideration include: waivers, transport and when participants should leave and return each day.
 
 ### Dedicated Wellbeing Support
+
 Appoint one or more welfare or wellbeing support people whose sole responsibility will be to support and monitor participant welfare. This role formalises care as a structured responsibility rather than leaving it to chance.
 
 The support person(s) will circulate amongst teams, check in proactively and be a visible, approachable point of contact for students.
 
 ### Messaging
+
 Ensure that safeguarding information about sleep, safety, food and support on-site is included in dvance communications with participants about the hackathon. This messaging should be reinforced throughout the hackathon.
 
 ## Resulting Context
-Students experience the hackathon as an intensive but sustainable event. 
+
+Students experience the hackathon as an intensive but sustainable event.
 
 Hackathon organizers can meet their duty of care with confidence.
 
@@ -78,22 +91,26 @@ Mentors have clear direction on the behaviours expected of them.
 In the longer term, consistent modelling and enforcing of wellbeing norms can influence what participants come to expect and value — moving away from the glorification of exhaustion and towards a healthier, more inclusive vision of what collaborative innovation looks like.
 
 ### Additional Learning from Carnegie Mellon University OSPO
-We have a policy of advocating for sleep. 
 
-We also try to have food and water on hand so that students aren’t making food runs at 3am when they're sleep deprived. 
+We have a policy of advocating for sleep.
+
+We also try to have food and water on hand so that students aren’t making food runs at 3am when they're sleep deprived.
 
 We always have a non-participating support person who makes sure all teams are safe, feeling good, working well and that they don't need anything.
 
 ### Additional Learning from University of Texas at Austin OSPO
-We give explicit directions for sleep and we provide a mechanism to ensure that students get sleep. 
+
+We give explicit directions for sleep and we provide a mechanism to ensure that students get sleep.
 
 Every team has a mentor
 
 ## Known Instances
+
 - [CMU Open Source Program Office](https://www.library.cmu.edu/services/ospo), CMU Libraries, Carnegie Mellon University
 - [The University of Texas OSPO (UT-OSPO)](https://opensource.utexas.edu/), University of Texas at Austin
 
 ### Related Patterns
+
 - [Organize an Open Source Hackathon](organize-an-open-source-hackathon.md)
 - [Design a Collaborative Open Source Hackathon](design-a-collaborative-open-source-hackathon.md)
 - [Enable Student-led Hackathons](enable-student-led-hackathons.md)
@@ -102,9 +119,10 @@ Every team has a mentor
 - [Lower the barriers to entry for Student Hackathons](lower-the-barriers-to-entry-for-student-hackathons.md)
 
 ## Contributors & Acknowledgement
+
 - Angela Newell, University of Texas at Austin
-- Ciara Flanagan, https://orcid.org/0009-0005-3153-7673
-- David Lippert, George Washington University, https://orcid.org/0009-0003-6444-9595
-- Emily Lovell, University of California Santa Cruz, https://orcid.org/0000-0001-5531-5956
+- Ciara Flanagan, <https://orcid.org/0009-0005-3153-7673>
+- David Lippert, George Washington University, <https://orcid.org/0009-0003-6444-9595>
+- Emily Lovell, University of California Santa Cruz, <https://orcid.org/0000-0001-5531-5956>
 - Laura Langdon, University of California, Davis
-- Tom Hughes, Carnegie Mellon University, https://orcid.org/0009-0008-7516-3687
+- Tom Hughes, Carnegie Mellon University, <https://orcid.org/0009-0008-7516-3687>

--- a/embedding-the-ospo-as-research-infrastructure.md
+++ b/embedding-the-ospo-as-research-infrastructure.md
@@ -8,23 +8,23 @@ tags:
 ---
 # Embedding the OSPO as Research Infrastructure
 
-### Pattern Summary
+## Pattern Summary
 
 The OSPO can be embedded as a core research facility of its university through a range of strategic, value-led actions.
 
-### Problem / Challenge
+## Problem / Challenge
 
 Academic OSPOs need to demonstrate relevance to senior leadership at their institutions and ensure their long term future.
 
-### Pattern Category
+## Pattern Category
 
 * Advocacy & Policy
 * Demonstrating value as an Academic OSPO
-* Funding & Financial Support 
+* Funding & Financial Support
 * OSS Education & Skills  
-* Supporting OSS development   
+* Supporting OSS development
 
-### Context
+## Context
 
 A research university creating large volumes of research outputs across every discipline.
 
@@ -32,7 +32,7 @@ An OSPO has been established on a short-term funding model.
 
 There is a gap in long-term funding and it’s unclear whether the OSPO will be sustained afterwards.
 
-### Forces
+## Forces
 
 When decision makers and OSPO champions move to other organizations, their original priorities and support for the OSPO may shift under new leadership.
 
@@ -40,89 +40,87 @@ New senior leaders may not be fully aware of the importance of OSS or the value 
 
 Other offices may not know of the university OSPO and how it can support them.
 
-### Solution
+## Solution
 
 Strengthen the OSPO’s prospects for sustainable funding and support by establishing it as an integral part of the university’s research infrastructure and an essential component of its research environment.
 
 The solution below outlines some core activities to consider:
 
-#### Seek partnership with or sponsorship from the Provost or Research Vice President
+### Seek partnership with or sponsorship from the Provost or Research Vice President
 
 * Connect early and regularly.
 
 * Clearly outline and align the OSPO with university research goals.
 
-#### Engage with and develop cross-campus partnerships with other key stakeholders
+### Engage with and develop cross-campus partnerships with other key stakeholders
 
-* Develop approaches for marketing OSPO support with relevant faculty, researchers and senior leadership. 
+* Develop approaches for marketing OSPO support with relevant faculty, researchers and senior leadership.
 
-* Attend regular meetings with senior leadership as a platform to share resources, identify needs and to demonstrate value. This may include meetings with the 
-  Provost’s Office, Research Administration Office, Office of Development, College, School and Unit (CSU) Research Deans and the Research Compute/Information 
+* Attend regular meetings with senior leadership as a platform to share resources, identify needs and to demonstrate value. This may include meetings with the
+  Provost’s Office, Research Administration Office, Office of Development, College, School and Unit (CSU) Research Deans and the Research Compute/Information
   Office.
 
-* Provide Development Office staff with facility statements, templates (e.g. open source grant commitment letters) and ‘how to’ resource guidance on funding 
+* Provide Development Office staff with facility statements, templates (e.g. open source grant commitment letters) and ‘how to’ resource guidance on funding
   requests.
 
 * Request inclusion in all communications and learning offerings from the CSU Research Deans and Research Compute/Information Offices.
 
-#### Operate as a core research function
+### Operate as a core research function
 
-Typical activities may be to: 
+Typical activities may be to:
 
-* Create a research facility statement, resource statements and/or grant fulfillment/requirement templates that may be included as part of grant applications and grant reporting. 
+* Create a research facility statement, resource statements and/or grant fulfillment/requirement templates that may be included as part of grant applications and grant reporting.
 
 * Connect the facility statement and resource statements to grant templates, data management planning tools and reporting templates.
 
 * Include facility and resource statements and templates with the Office of Development, research administration, faculty and researcher development, libraries, research resources databases, university and library help desks.
 
-* Request inclusion in annual research communications from CSUs to researchers, Principal Investigators (PIs) and resource communications. 
+* Request inclusion in annual research communications from CSUs to researchers, Principal Investigators (PIs) and resource communications.
 
 * Participate in the Research Administration Office, faculty, PI, researcher, and graduate student orientations, research events and communications.
 
-*  Anchor service to existing open education, science, research efforts.
+* Anchor service to existing open education, science, research efforts.
 
-#### Map the needs of key user groups to inform OSPO activity
+### Map the needs of key user groups to inform OSPO activity
 
-* Create a methodology for ecosystem activity (e.g. the [UT OSPO Participation Pathway](https://opensource.utexas.edu/resources)). 
+* Create a methodology for ecosystem activity (e.g. the [UT OSPO Participation Pathway](https://opensource.utexas.edu/resources)).
 
 * Craft training and guidance to help users at different points of open source development in their research.
 
-#### Evaluate and communicate resources
+### Evaluate and communicate resources
 
 * Provide a regular account of offerings. (Being able to relate services back to operational methodology or a participation pathway provides additional clarity for key stakeholders.)
 
-* Communicate to audiences across the institution of the OSPO’s successes, Challenges (use this an opportunity to request input), facilities and resources, and 
+* Communicate to audiences across the institution of the OSPO’s successes, Challenges (use this an opportunity to request input), facilities and resources, and
   Support services.
 
 * Communicate alignment with University priorities and goals and the OSPO's role in fulfilling those goals.
 
-### Resulting Context
+## Resulting Context
 
 The intended outcome is that an OSPO becomes a sustainable department that is core to the university research environment.
 
-#### Additional learning from the UT Austin OSPO
+### Additional learning from the UT Austin OSPO
 
 Building relationships in the leadership space; communicating about the OSPO and getting it on every database; providing templates and resources; and designing training based on listening to the community is where we’re finding success.
 
-### Known Instances
+## Known Instances
 
 * [The University of Texas OSPO (UT-OSPO)](https://opensource.utexas.edu/), University of Texas at Austin
 * [CMU Open Source Program Office](https://www.library.cmu.edu/services/ospo), CMU Libraries, Carnegie Mellon University
 * [The GW Open Source Program Office](https://ospo.gwu.edu/), The George Washington University
 
-### References
+## References
 
 * [The UT OSPO Open Source Participation Pathway](https://opensource.utexas.edu/resources) - an outline of the different stages of open source projects within the context of research development. This pathway is used as a reference point for engaging with user groups and identifying their needs at different points of the pathway.
 * [Open Source Grant Commitment Letter](./open-source-grant-commitment-letter.md) - Pattern from the George Washington University OSPO
 * [Supporting grant proposals with an open source componence](./supporting-grant-proposals-with-an-open-source-component.md) - Pattern from Carnegie Mellon University OSPO
 
-
-### Contributors & Acknowledgement
+## Contributors & Acknowledgement
 
 * Dr. Angela Newell (University of Texas at Austin)
 * Dr. Alex Marden (University of Texas at Austin)
 * Dr. Jennifer Schopf (University of Texas at Austin)
 * Michael Shensky (University of Texas at Austin)
 * Michelle McDermott (University of Texas at Austin)
-* Ciara Flanagan, https://orcid.org/0009-0005-3153-7673
-
+* Ciara Flanagan, <https://orcid.org/0009-0005-3153-7673>

--- a/enable-student-led-hackathons.md
+++ b/enable-student-led-hackathons.md
@@ -9,38 +9,44 @@ tags:
 # Enable Student-led Hackathons
 
 ## Pattern Summary
+
 Support student hackathon organizers by acting as institutional advocates and managing bureaucratic processes that fall outside their reach.
 
 ## Problem / Challenge
-Student groups are often highly capable at organizing hackathons. However, organizers may face barriers when engaging with the broader university or external partners in the following areas: 
 
-* Applying for funding. 
+Student groups are often highly capable at organizing hackathons. However, organizers may face barriers when engaging with the broader university or external partners in the following areas:
+
+* Applying for funding.
 * Prior experience of managing events of this scale.
 * Knowledge of how to navigate their university’s administrative teams (e.g. IT, Communications, Finance, Facilities, Student Affairs) to obtain approval, resources and support.
 * Financial structures in place to administer funding from sponsors.
-* Know-how to integrate open source best practices and culture into the event. 
+* Know-how to integrate open source best practices and culture into the event.
 * An official from the university who can advocate on their behalf.
 
 Without proper support, student hackathons may fail to launch, produce limited learning outcomes or inadvertently create problems around intellectual property, code licensing, or project sustainability.
 
 ## Pattern Category
-- Community Building
-- Education & Skills
-- Funding & Financial Support
-- Promoting Best Practices
-- Working with Tech Transfer/External Partners  
-   
+
+* Community Building
+* Education & Skills
+* Funding & Financial Support
+* Promoting Best Practices
+* Working with Tech Transfer/External Partners  
+
 ## Context
+
 An institution or a university.
 An OSPO has been established and has contacts with student groups involved in hackathons.
 Student organizers have experience of running hackathons.
 
 ## Forces
-Funding has become available for a hackathon (possibly through external sponsorship). 
+
+Funding has become available for a hackathon (possibly through external sponsorship).
 OSPO staff have the time and resources to support student organisers.
 The student organizers have some level of experience in leading or participating in hackathons.
 
 ## Solution
+
 OSPOs should identify organizers' support needs in the following areas:
 
 * Support with financial and legal processes (e.g. providing a bank account to host funding, support with contracts, guarantees, Memoranda of Understanding).
@@ -48,35 +54,40 @@ OSPOs should identify organizers' support needs in the following areas:
 * Connecting organizers with other student hackathon groups on campus to share learning.
 * Acting as an institutional advocate for student organizers in their negotiations with external partners. This may involve attending meetings; supporting the organizers’ ideas during negotiations; and providing a wider institutional context.
 * Advocating on behalf of organizers with the university.
-* Attending hackathons and supporting organizers throughout the event. 
+* Attending hackathons and supporting organizers throughout the event.
 
 ## Resulting Context
+
 * Student groups retain full ownership and pride in their events while gaining access to resources and partnerships they couldn't reach alone.
 * The OSPO builds genuine, sustained relationships with student communities and gains visibility and credibility across disciplines.
 * External partners (industry, community open source groups) are assured that the institution has a trusted representative with the experience to support student organizers to fulfill their commitments.
 
 ### Additional Learning from the George Washington University OSPO
+
 [GeorgeHacks](https://www.georgehacks.org/#about) is a student group that runs an annual hackathon. It’s a two day event with approximately 150 participants. They have industry partners and collaborate with them to devise problem statements. This is a very experienced group and we have a really good relationship with the group. (Their lead is on our [OSPO Stakeholder Group](ospo-advisory-board.md).)
 
-In 2025, we partnered as sponsors and the theme for the hackathon was based on our suggestion of the [UN Sustainable Development Goals](https://sdgs.un.org/goals). We ran a workshop introducing the UN SDGs. 
-We facilitated an introductory open source workshop and sponsored an open source prize. Teams who made their projects open source and followed explicit guidelines (e.g. sharing on GitHub, adding the correct license etc.) qualified for a $500 spot prize. 
+In 2025, we partnered as sponsors and the theme for the hackathon was based on our suggestion of the [UN Sustainable Development Goals](https://sdgs.un.org/goals). We ran a workshop introducing the UN SDGs.
+We facilitated an introductory open source workshop and sponsored an open source prize. Teams who made their projects open source and followed explicit guidelines (e.g. sharing on GitHub, adding the correct license etc.) qualified for a $500 spot prize.
 
 We also participated as mentors.
 
 ### Additional Learning from Carnegie Mellon University OSPO
+
 We have different students from a variety of disciplines in leadership roles so every student-led hackathon is different. We connect organizers to other student groups to enable information sharing. We’ve also facilitated peer-to-peer leadership training, which has been really valuable.
 
-With external partners, it can be challenging for students to engage with sponsors because of university bureaucracy. We can step in and act as the connection point and we can also look after contracts, guarantees and any MoU. 
+With external partners, it can be challenging for students to engage with sponsors because of university bureaucracy. We can step in and act as the connection point and we can also look after contracts, guarantees and any MoU.
 
-We’ve found that the big thing that student organizers need is an advocate. 
+We’ve found that the big thing that student organizers need is an advocate.
 
 ## Known Instances
-- [CMU Open Source Program Office](https://www.library.cmu.edu/services/ospo), CMU Libraries, Carnegie Mellon University
-- [GW OSPO](https://ospo.gwu.edu/), George Washington University
-- [University of California OSPO Network](https://ucospo.net/)
-- [UCSC OSPO](https://ucsc-ospo.github.io/). University of California, Santa Cruz
+
+* [CMU Open Source Program Office](https://www.library.cmu.edu/services/ospo), CMU Libraries, Carnegie Mellon University
+* [GW OSPO](https://ospo.gwu.edu/), George Washington University
+* [University of California OSPO Network](https://ucospo.net/)
+* [UCSC OSPO](https://ucsc-ospo.github.io/). University of California, Santa Cruz
 
 ## References
+
 * [George Hacks 2025](https://ospo.gwu.edu/george-hacks-2025)
 * [OpenHatch: Open Source Comes to Campus](https://github.com/openhatch/open-source-comes-to-campus)
 * [UCSC GraceHacks 2023 repository](https://github.com/emmet0r/gracehacks)
@@ -85,18 +96,20 @@ We’ve found that the big thing that student organizers need is an advocate.
 * [UCSC’s 2024 Ideathon (included OSPO-sponsored prize track)](https://lu.ma/d8afz220)
 
 ### Related Patterns
-- [Co-hosting student events](cohosting-student-events.md)
-- [Organize an Open Source Hackathon](organize-an-open-source-hackathon.md)
-- [Design a Collaborative Open Source Hackathon](design-a-collaborative-open-source-hackathon.md)
-- [Embed wellbeing into Student Hackathons](embed-wellbeing-into-student-hackathons.md)
-- [Engage a Hackathon Facilitator](engage-a-hackathon-facilitator.md)
-- [Collaborate with External Partners on Open Source Hackathons](collaborate-with-external-partners-on-open-source-hackathons.md)
-- [Lower the barriers to entry for Student Hackathons](lower-the-barriers-to-entry-for-student-hackathons.md)
+
+* [Co-hosting student events](cohosting-student-events.md)
+* [Organize an Open Source Hackathon](organize-an-open-source-hackathon.md)
+* [Design a Collaborative Open Source Hackathon](design-a-collaborative-open-source-hackathon.md)
+* [Embed wellbeing into Student Hackathons](embed-wellbeing-into-student-hackathons.md)
+* [Engage a Hackathon Facilitator](engage-a-hackathon-facilitator.md)
+* [Collaborate with External Partners on Open Source Hackathons](collaborate-with-external-partners-on-open-source-hackathons.md)
+* [Lower the barriers to entry for Student Hackathons](lower-the-barriers-to-entry-for-student-hackathons.md)
 
 ## Contributors & Acknowledgement
-- Angela Newell, University of Texas at Austin
-- Ciara Flanagan, https://orcid.org/0009-0005-3153-7673
-- David Lippert, George Washington University, https://orcid.org/0009-0003-6444-9595
-- Emily Lovell, University of California Santa Cruz, https://orcid.org/0000-0001-5531-5956
-- Laura Langdon, University of California, Davis
-- Tom Hughes, Carnegie Mellon University, https://orcid.org/0009-0008-7516-3687
+
+* Angela Newell, University of Texas at Austin
+* Ciara Flanagan, <https://orcid.org/0009-0005-3153-7673>
+* David Lippert, George Washington University, <https://orcid.org/0009-0003-6444-9595>
+* Emily Lovell, University of California Santa Cruz, <https://orcid.org/0000-0001-5531-5956>
+* Laura Langdon, University of California, Davis
+* Tom Hughes, Carnegie Mellon University, <https://orcid.org/0009-0008-7516-3687>

--- a/engage-a-hackathon-facilitator.md
+++ b/engage-a-hackathon-facilitator.md
@@ -8,23 +8,28 @@ tags:
 # Engage a Hackathon Facilitator
 
 ## Pattern Summary
-Engage experienced external facilitators to design and run student hackathons on behalf of the university. 
+
+Engage experienced external facilitators to design and run student hackathons on behalf of the university.
 
 ## Problem / Challenge
+
 Student hackathons are complex undertakings requiring engaging problem sets, project management, multi-stakeholder liaison and multi-day event organization.
 
 Without experienced facilitation, hackathons risk being poorly structured and unable to deliver meaningful learning or innovation outcomes for students.
 
 ## Pattern Category
+
 - Community Building
 - Education & Skills
 - Promoting Best Practices
 - Working with Tech Transfer / External Partners  
-   
+
 ## Context
+
 A university has funding to deliver a hackathon.
 
 ## Forces
+
 University or OSPO staff may be running their first or early hackathons where internal know-how is still being developed.
 
 University or OSPO staff may have limited staff capacity to manage both the logistics and facilitation of the hackathon.
@@ -32,44 +37,50 @@ University or OSPO staff may have limited staff capacity to manage both the logi
 An industry partner or sponsor may have expressed an interest in engaging students through structured, problem-focused hackathons.
 
 ## Solution
-Engage an external facilitator or industry partner who can provide end-to-end structure, domain expertise and on-the-ground management for the hackathon. 
 
-Universities can source and work with facilitators through industry partnerships or by hiring external hackathon facilitators. 
+Engage an external facilitator or industry partner who can provide end-to-end structure, domain expertise and on-the-ground management for the hackathon.
+
+Universities can source and work with facilitators through industry partnerships or by hiring external hackathon facilitators.
 
 ### Leverage industry partners as embedded facilitators
-Industry partners (e.g. technology companies, biomedical firms or sector-specific organisations) often offer: 
 
-* A defined problem set for participants to work on.
-* A pre-planned structure covering day-by-day agendas.
-* Their own team leads and mentors to guide student teams.
-* A checklist of what they need from the university (venue, food, diversity considerations, etc.).
+Industry partners (e.g. technology companies, biomedical firms or sector-specific organisations) often offer:
+
+- A defined problem set for participants to work on.
+- A pre-planned structure covering day-by-day agendas.
+- Their own team leads and mentors to guide student teams.
+- A checklist of what they need from the university (venue, food, diversity considerations, etc.).
 
 ### Allocate a dedicated budget for professional facilitation
+
 Universities may also use a portion of their hackathon budget to hire a professional facilitator. Any budget or terms of agreement should consider the following:
 
-* **The scale and duration of the hackathon:** A multi-day event will require more facilitation resources than a one-day sprint.
-* **The facilitator’s role** in designing challenges and/or delivering on a predetermined agenda.
+- **The scale and duration of the hackathon:** A multi-day event will require more facilitation resources than a one-day sprint.
+- **The facilitator’s role** in designing challenges and/or delivering on a predetermined agenda.
   
-#### Source Facilitators 
+#### Source Facilitators
+
 Universities can identify hackathon facilitators through a range of channels:
 
-* **Academic innovation and entrepreneurship networks:** Technology transfer offices, incubators, and entrepreneurship programmes often have connections to experienced hackathon facilitators.
-* **Industry associations** Sector bodies in areas such as life sciences, sustainability, fintech or engineering frequently run or support hackathons and may be able to recommend facilitators.
-* **Peer institution referrals:** Universities that have run successful hackathons can share recommendations through peer consortia or sector networks.
-* **Alumni networks:** Former students who have moved into innovation, product, or startup roles may be well-placed to facilitate events or refer facilitators.
+- **Academic innovation and entrepreneurship networks:** Technology transfer offices, incubators, and entrepreneurship programmes often have connections to experienced hackathon facilitators.
+- **Industry associations** Sector bodies in areas such as life sciences, sustainability, fintech or engineering frequently run or support hackathons and may be able to recommend facilitators.
+- **Peer institution referrals:** Universities that have run successful hackathons can share recommendations through peer consortia or sector networks.
+- **Alumni networks:** Former students who have moved into innovation, product, or startup roles may be well-placed to facilitate events or refer facilitators.
 
 ### Role expectations and Deliverables
+
 Whether working with an industry partner or a hired facilitator, universities should agree upfront on:
 
-* The number and nature of the hackathon challenges.
-* The event structure, including a day-by-day or session-by-session agenda.
-* How student teams will be formed or selected.
-* The facilitator's role during the event (active facilitation, mentoring, judging or a combination).
-* Infrastructure responsibilities — what the university provides versus what the facilitator manages.
+- The number and nature of the hackathon challenges.
+- The event structure, including a day-by-day or session-by-session agenda.
+- How student teams will be formed or selected.
+- The facilitator's role during the event (active facilitation, mentoring, judging or a combination).
+- Infrastructure responsibilities — what the university provides versus what the facilitator manages.
   
 A written agreement or detailed briefing document protects both parties and reduces the risk of misaligned expectations on the day.
 
 ## Resulting Context
+
 **High quality event:** Universities with limited experience of running hackathons can still provide high quality events with clear agendas, excellent team support and strong student engagement.
 
 **Reduced organizational burden:** The workload for university and OSPO staff is significantly reduced.
@@ -79,28 +90,32 @@ A written agreement or detailed briefing document protects both parties and redu
 **Growing internal capacity:** With each facilitated hackathon, university staff learn more about hackathon methodologies. Over time, they may develop sufficient internal capability to self-facilitate.
 
 ### Additional Learning from Carnegie Mellon University OSPO
+
 The facilitation role is a big part of working with external partners.
 
 In the case of industry experts, It’s not just about funding. Partners often have a playbook of how they want to run a hackathon. Often they’ll come in with a defined problem set and a structure for the event and we partner with them to run the structure.
 
-Another example is an external facilitator that we used. They came in with a structure and also selected the teams; brought in team leads; designed the problem set; and provided a plan of how the hackathon would be run each day. They also had a checklist of what they needed from us. 
+Another example is an external facilitator that we used. They came in with a structure and also selected the teams; brought in team leads; designed the problem set; and provided a plan of how the hackathon would be run each day. They also had a checklist of what they needed from us.
 
 This was a big draw for us as we knew well ahead of time how many problems they would tackle and the resources involved. We had a laundry list that we could then share with colleagues.
 
 ### Additional Learning from University of Texas at Austin UT OSPO
-A portion of our hackathon budget is allocated to a facilitator. 
+
+A portion of our hackathon budget is allocated to a facilitator.
 
 During the design phase, he meets with our team and the relevant school that will be involved.
 
 Now, we’ve run enough hackathons that we could probably facilitate ourselves.
 
 ## Known Instances
+
 - [CMU Open Source Program Office](https://www.library.cmu.edu/services/ospo), CMU Libraries, Carnegie Mellon University
 - [The University of Texas OSPO (UT-OSPO)](https://opensource.utexas.edu/), University of Texas at Austin
 
 ## References
 
 ### Related Patterns
+
 - [Organize an Open Source Hackathon](organize-an-open-source-hackathon.md)
 - [Design a Collaborative Open Source Hackathon](design-a-collaborative-open-source-hackathon.md)
 - [Enable Student-led Hackathons](enable-student-led-hackathons.md)
@@ -109,9 +124,10 @@ Now, we’ve run enough hackathons that we could probably facilitate ourselves.
 - [Lower the barriers to entry for Student Hackathons](lower-the-barriers-to-entry-for-student-hackathons.md)
 
 ## Contributors & Acknowledgement
+
 - Angela Newell, University of Texas at Austin
-- Ciara Flanagan, https://orcid.org/0009-0005-3153-7673
-- David Lippert, George Washington University, https://orcid.org/0009-0003-6444-9595
-- Emily Lovell, University of California Santa Cruz, https://orcid.org/0000-0001-5531-5956
+- Ciara Flanagan, <https://orcid.org/0009-0005-3153-7673>
+- David Lippert, George Washington University, <https://orcid.org/0009-0003-6444-9595>
+- Emily Lovell, University of California Santa Cruz, <https://orcid.org/0000-0001-5531-5956>
 - Laura Langdon, University of California, Davis
-- Tom Hughes, Carnegie Mellon University, https://orcid.org/0009-0008-7516-3687
+- Tom Hughes, Carnegie Mellon University, <https://orcid.org/0009-0008-7516-3687>

--- a/event-tabling.md
+++ b/event-tabling.md
@@ -5,22 +5,22 @@ tags:
   - Education & Skills
   - Open Source Discovery
 ---
-# Event Tabling 
+# Event Tabling
 
 ## Pattern Summary
 
-Learn how to run a tabling event with games, interactive open source activities and prizes to engage students across the university. 
+Learn how to run a tabling event with games, interactive open source activities and prizes to engage students across the university.
 
- # Problem 
+# Problem
 
 Open Source programming is aimed at fostering collaboration - especially at university OSPOs. However, it can be challenging to meaningfully engage with busy students, faculty, and staff who work across diverse disciplines and are unaware of how the OSPO can benefit their work.
 
- # Pattern Category
+# Pattern Category
 
 * Awareness
 * Community building
 * Education & Skills
-* Open Source Discovery 
+* Open Source Discovery
 
 ## Context
 
@@ -34,31 +34,33 @@ A university with an established OSPO interested in student engagement.
 
 ## Solution
 
-Host an 'Open Source' or OSPO table at a wider campus event to connect with students, faculty and staff and to promote the OSPO. 
+Host an 'Open Source' or OSPO table at a wider campus event to connect with students, faculty and staff and to promote the OSPO.
 
 ### Preparation
 
 The following tasks may be worth considering:
+
 * Practice a brief pitch for those who have never heard of open source and the OSPO office.
 * Have OSPO merch, candy or other goodies available.
-* Create and make accessible flyers or a scannable QR with more information about your OSPO so interested individuals know where to look to continue their engagement with your OSPO office. 
+* Create and make accessible flyers or a scannable QR with more information about your OSPO so interested individuals know where to look to continue their engagement with your OSPO office.
 
 ### Interactive Activities and Conversation Starters
 
 Feature interactive activities that offer a brief introduction to open source. Activities may demonstrate to students that they have used open sources platforms, and the power of sharing work in the open. The two activities below serve as useful examples:
 
-* **Open Source vs. Proprietary Matching Game (Activity 1):** Visitors match company logos, platforms and apps and guess which are open-source models and which are closed-source. This activity highlights how open source models are a part of daily life, even when people may not realize it. 
+* **Open Source vs. Proprietary Matching Game (Activity 1):** Visitors match company logos, platforms and apps and guess which are open-source models and which are closed-source. This activity highlights how open source models are a part of daily life, even when people may not realize it.
 Open source platforms to include: R, Drupal, WordPress, Linux, Python, Open Street Map, React, Bluesky, Docker, Gimp, Android and Jupyter.
 Proprietary platforms to include ChatGPT, Gmail, Facebook, TikTok, X, GitHub, Slack, Adobe, WhatsApp, MailChimp.
 
-* **Open Source Art Contribution (Activity 2):** Provide students with an opportunity to showcase their creativity by creating artwork and participating in their first open source contribution on GitHub. Allow participants to draw something on a piece of paper. Staff demonstrate to students how to upload their artwork to GitHub (or any open source repository). Students then see their artworks uploaded live as a part of a collaborative open source art collection. 
+* **Open Source Art Contribution (Activity 2):** Provide students with an opportunity to showcase their creativity by creating artwork and participating in their first open source contribution on GitHub. Allow participants to draw something on a piece of paper. Staff demonstrate to students how to upload their artwork to GitHub (or any open source repository). Students then see their artworks uploaded live as a part of a collaborative open source art collection.
 
 ## Resulting Context
 
-Tabling is an effective way to briefly introduce the OSPO to the wider campus community in an informal and meaningful way. 
+Tabling is an effective way to briefly introduce the OSPO to the wider campus community in an informal and meaningful way.
 
 ### Additional Learning from the GW Open Source Program Office
-The George Washington University Open Source Program Office tabled at a [makerspace event hosted by a student-run organization GeorgeHacks](https://ospo.gwu.edu/georgehacks-makerspace-2025). 
+
+The George Washington University Open Source Program Office tabled at a [makerspace event hosted by a student-run organization GeorgeHacks](https://ospo.gwu.edu/georgehacks-makerspace-2025).
 
 The GW OSPO Student Ambassadors tabled the event and were able to meaningfully connect with students, advertise their upcoming events, and increase open source awareness with students from a variety of disciplines and backgrounds.
 
@@ -73,11 +75,12 @@ This event was a fantastic opportunity to meet so many members of our community,
 ## References
 
 ### Related Patterns
+
 * [OSPO Student Ambassador Program](./ospo-student-ambassador-program.md)
 * [Student Outreach Strategy](./student-outreach-strategy.md)
 
 ## Contributors & Acknowledgements
 
-Nouha Elyazidi, George Washington University, https://orcid.org/my-orcid?orcid=0009-0004-8067-8803 
+Nouha Elyazidi, George Washington University, <https://orcid.org/my-orcid?orcid=0009-0004-8067-8803>
 
-Ciara Flanagan, https://orcid.org/0009-0005-3153-7673
+Ciara Flanagan, <https://orcid.org/0009-0005-3153-7673>

--- a/facilitate-connections-at-open-source-conferences.md
+++ b/facilitate-connections-at-open-source-conferences.md
@@ -6,11 +6,12 @@ tags:
 
 ## Pattern Summary
 
-Facilitate relationship building opportunities at open source/academic OSPO conferences by incorporating intentional introductory activities or interaction badges. 
+Facilitate relationship building opportunities at open source/academic OSPO conferences by incorporating intentional introductory activities or interaction badges.
 
 These low barrier prompts support attendees to overcome social hesitation and initiate relevant conversations.
 
 ## Problem / Challenge
+
 A core objective of an academic OSPO conference is to share learning and foster collaborative relationships that will ultimately promote the advancement of open source. However, there are a number of logistic challenges:
 
 * Conference agendas are often dense with presentations and workshops, leaving little unstructured time for networking. Without intentional design, opportunities to connect may be missed.
@@ -20,6 +21,7 @@ A core objective of an academic OSPO conference is to share learning and foster 
 * Attendees tend to stay with existing contacts and familiar faces. The ‘social clustering’ effect inhibits the cross-pollination of ideas and the relationships that OSPOs aim to foster.
 
 ## Pattern Category
+
 Building University OSS Community
 
 ## Context
@@ -37,9 +39,11 @@ An OSPO with the capacity to organize / co-organize events.
 An event or conference has been organized by the OSPO.
 
 ## Solution
-Build low-pressure icebreaker activities and conversation starting tools that support connection making into the conference experience. 
 
-Examples may include: 
+Build low-pressure icebreaker activities and conversation starting tools that support connection making into the conference experience.
+
+Examples may include:
+
 * [Interaction badges](https://stimpunks.org/fieldguide/events/access/interaction-badges/) with prompts such as ‘Ask me about …’ or ‘Seeking partnerships in …’
 * Structured mingling activities such as speed networking where attendees rotate and have brief timed conversations with each other.
 * Roundtables that create targeted opportunities for attendees to find collaborators, mentors, or contributors who aligned with their open source or academic goals.
@@ -47,41 +51,49 @@ Examples may include:
 
 ## Resulting Context
 
-Strategic connection activities and tools minimize networking anxiety, establish clear conversation pathways, and support attendees to identify collaboration opportunities. 
+Strategic connection activities and tools minimize networking anxiety, establish clear conversation pathways, and support attendees to identify collaboration opportunities.
 
-They also offer strategic and cultural benefits for academic OSPOs including: 
-* The use of intentional networking activities and tools demonstrates OSPO values such as openness, collaboration, transparency, and community stewardship. 
+They also offer strategic and cultural benefits for academic OSPOs including:
+
+* The use of intentional networking activities and tools demonstrates OSPO values such as openness, collaboration, transparency, and community stewardship.
 * Structured relationship building reinforces the OSPO brand as an essential ‘connector’ of people and projects within the open source ecosystem.
 * Academic OSPOs often convene researchers from various fields. Connection tools  allow attendees from diverse disciplines to efficiently discover mutual interests and identify common ground.
 * Icebreakers and tools democratize conversation by empowering introverts, first-time attendees, or underrepresented voices to engage. A well-designed badge or structured activity offers a non-threatening entry point to dialogue and contributes to a more welcoming and equitable environment.
 * Stronger interpersonal connections lead to more follow-up conversations, project collaborations and sustained engagement after the event - ultimately extending the conference’s impact well beyond its duration.
 
 ### Additional Learning from University of California Santa Cruz OSPO, UC OSPO Network
+
 Right before the reception at the end of our event, we facilitated a round of ‘Lightning Intros’ of 30 seconds to one minute. Anybody could get up, introduce themselves and say what they wanted to talk about with people. It was really fun. We saw people taking notes about who they wanted to talk to. We got good feedback on the exercise.
 
 We advertised the lightning intros in advance of the event. We also personally emailed people whom we hoped would participate. We reminded people to sign up for the Lightning Intros on the morning of the event.
 
 ### Additional Learning from Carnegie Mellon University OSPO
-I attended an event where organizers added a color to your name badge to signal the topic you wanted to talk about. At the reception that evening, I saw another attendee with the same color badge and we immediately started talking. 
+
+I attended an event where organizers added a color to your name badge to signal the topic you wanted to talk about. At the reception that evening, I saw another attendee with the same color badge and we immediately started talking.
 I definitely appreciated it and I think it made it much easier for people to have an initial conversation.
 
 ### Additional Learning from GW Open Source Program Office
+
 We had a “Contributors Hub” at GW OSCON with coffee, food and tables for sponsors and GW organizations. We scheduled long breaks throughout the day and encouraged attendees to check it out.
 
 We also included an [open source art activity](https://gw-ospo.github.io/gwoscon2025/) to guide people to make their first open source contribution. This was a simple photo of a drawing uploaded to our project. Each new merged PR was displayed on a big screen using p5.js.
 
 ### Additional Learning from University of California Davis OSPO, UC OSPO Network
-Something I've seen at an event is attaching ribbons to the bottom of your name badge to represent a number of topics that you may want to talk about with others. This worked really well. 
+
+Something I've seen at an event is attaching ribbons to the bottom of your name badge to represent a number of topics that you may want to talk about with others. This worked really well.
 
 ## Known Instances
+
 * [GW Open Source Program Office](https://ospo.gwu.edu/), The George Washington University
 * [UC Santa Cruz OSPO](https://ucsc-ospo.github.io/), University of California Santa Cruz, [University of California OSPO Network](https://ucospo.net/)
 
 ## References
+
 * [GW OSCON 2025](https://ospo.gwu.edu/oscon-2025)
-* [University of California Open Summit (UC Open) 2025](https://ucospo.net/events/uc-open-4-2025/) 
+* [University of California Open Summit (UC Open) 2025](https://ucospo.net/events/uc-open-4-2025/)
 
 ### Related Patterns
+
 * [Co-hosting student events](./cohosting-student-events.md)
 * [Host an Open Source Conference](./host-an-open-source-conference.md)
 * [Informal OSPO focus group sessions at Open Source Events](./informal-ospo-focus-groups-at-open-source-events.md)
@@ -91,11 +103,12 @@ Something I've seen at an event is attaching ribbons to the bottom of your name 
 * [Student Showcase Sessions at OSPO Events](./student-showcase-sessions-at-ospo-events.md)
 
 ## Contributors & Acknowledgement
+
 In alphabetical order
 
-* Ciara Flanagan, https://orcid.org/0009-0005-3153-7673
-* David Lippert, George Washington University, https://orcid.org/0009-0003-6444-9595
-* Emily Lovell, University of California Santa Cruz, https://orcid.org/0000-0001-5531-5956
+* Ciara Flanagan, <https://orcid.org/0009-0005-3153-7673>
+* David Lippert, George Washington University, <https://orcid.org/0009-0003-6444-9595>
+* Emily Lovell, University of California Santa Cruz, <https://orcid.org/0000-0001-5531-5956>
 * Laura Langdon, University of California Davis
-* Sayeed Choudhury, Carnegie Mellon University, https://orcid.org/0000-0003-2891-0543
-* Stephanie Lieggi, University of California Santa Cruz, https://orcid.org/0009-0000-5647-6540
+* Sayeed Choudhury, Carnegie Mellon University, <https://orcid.org/0000-0003-2891-0543>
+* Stephanie Lieggi, University of California Santa Cruz, <https://orcid.org/0009-0000-5647-6540>

--- a/framework-managing-university-oss.md
+++ b/framework-managing-university-oss.md
@@ -14,39 +14,40 @@ tags:
 
 ## OSPO Problem / Challenge
 
-Often universities do not have an open source policy. How can we help them create useful policies, charters or guidelines for better and consistent OSS practices? 
+Often universities do not have an open source policy. How can we help them create useful policies, charters or guidelines for better and consistent OSS practices?
 
 ## Context
 
-Open Source Software (OSS) and tools form a critical part of Open Research practices. However, often there is no consistent approach or advice offered by universities about how best to use, contribute to or produce OSS. Researchers in Ireland have varying degrees of knowledge about OSS principles, practices, processes and tools. 
+Open Source Software (OSS) and tools form a critical part of Open Research practices. However, often there is no consistent approach or advice offered by universities about how best to use, contribute to or produce OSS. Researchers in Ireland have varying degrees of knowledge about OSS principles, practices, processes and tools.
 
 ## Forces
 
-It can often be difficult for open source advocates to know how to approach getting institutional direction on open source work. It is even more difficult to ensure approaches are consistent across multiple universities who may have to collaborate together on projects. 
+It can often be difficult for open source advocates to know how to approach getting institutional direction on open source work. It is even more difficult to ensure approaches are consistent across multiple universities who may have to collaborate together on projects.
 
-Even the very idea of creating a new policy may be too challenging for some. 
+Even the very idea of creating a new policy may be too challenging for some.
 
 ## Solution
 
-* Create a framework to help universities more consistently support open source in their institutions.
-* Provide multiple options, in case there may be difficulty orchestrating policy change.
-* Include information about why open source is important, and specifically important in a university setting to help convince stakeholders this is necessary.
-* Do not assume prior knowledge of open source, or its importance.  
+- Create a framework to help universities more consistently support open source in their institutions.
+- Provide multiple options, in case there may be difficulty orchestrating policy change.
+- Include information about why open source is important, and specifically important in a university setting to help convince stakeholders this is necessary.
+- Do not assume prior knowledge of open source, or its importance.  
 
 ## Resulting Context
 
 The resulting framework provides guidance about how to approach creating an open source framework. It includes the following sections:  
-* Introduction  
-* Key Recommendations  
-* What is open source?  
-* Why is open source important?  
-  * Addressing open source myths  
-* Open Source in Academia  
-  * Why is open source important in academia  
-  * Why an open source framework is essential for universities  
-  * Who engages with a university open source framework  
-  * Open Source roles in a university context  
-* Implementing an Open Source Framework
+
+- Introduction  
+- Key Recommendations  
+- What is open source?  
+- Why is open source important?  
+  - Addressing open source myths  
+- Open Source in Academia  
+  - Why is open source important in academia  
+  - Why an open source framework is essential for universities  
+  - Who engages with a university open source framework  
+  - Open Source roles in a university context  
+- Implementing an Open Source Framework
 
 ## Known Instance
 
@@ -57,4 +58,3 @@ Lero \- Science Foundation Ireland’s Research Centre for Software. Spans 12 Ir
 ## Contributor(s) & Acknowledgment
 
 Clare Dillon, Lero
-

--- a/host-an-open-source-conference.md
+++ b/host-an-open-source-conference.md
@@ -18,7 +18,7 @@ Host a conference or high profile event on the theme of open source to increase 
 
 ## Problem / Challenge
 
-A lack of awareness and visibility of an academic OSPO may create a number of challenges for the OSPO including: 
+A lack of awareness and visibility of an academic OSPO may create a number of challenges for the OSPO including:
 
 * Students, faculty and staff may not know that the OSPO exists or understand its relevance to their work.
 * Open source efforts continue to take place in siloes across departments, research groups and student organizations.
@@ -26,14 +26,15 @@ A lack of awareness and visibility of an academic OSPO may create a number of ch
 * The OSPO experiences difficulties in connecting with internal and/or external partners.
 
 ## Pattern Category
-- Building University OSS Community
-- Demonstrating value as an OSPO
-- Funding & Financial Support
-- Raising awareness
-- Sharing OSS Best Practices
-- OSS Advocacy and Policy 
-- OSS Education & Skills  
-- Working with Tech Transfer / External Partners  
+
+* Building University OSS Community
+* Demonstrating value as an OSPO
+* Funding & Financial Support
+* Raising awareness
+* Sharing OSS Best Practices
+* OSS Advocacy and Policy
+* OSS Education & Skills  
+* Working with Tech Transfer / External Partners  
 
 ## Context
 
@@ -51,54 +52,63 @@ Resources are available to finance or part-fund the event.
 
 ## Solution
 
-Host a conference or large scale event to boost visibility of the OSPO and to foster networks with strategic partners. 
+Host a conference or large scale event to boost visibility of the OSPO and to foster networks with strategic partners.
 
 The following tasks cover the broad areas of work that will need to be undertaken:
 
 ### Assemble a planning team and program committee
+
 * Include representatives from faculty, students, administration and the OSPO.
 * Designate leads for logistics, communications, programming, registration and sponsorships.
 
 ### Define the purpose of the conference and the target audience
+
 * Clarify the event’s goal: awareness e.g., collaboration, training, research alignment, etc.
 * Identify primary audiences e.g., students, faculty, external partners, open source maintainers and/or members of the wider open source ecosystem.
 
 ### Choose the Format and Scope
+
 * Decide on a format e.g., a single-day symposium, a multi-day conference, hackathon, an unconference, etc.
 * Determine whether the event will be in-person, hybrid, or virtual.
 
 ### Secure Institutional Support
+
 * Get buy-in from university departments, IT, facilities and legal if necessary.
 * Consider co-branding with departments, research groups or external sponsors.
 
 ### Set a Budget and Seek Funding
+
 * Estimate costs e.g., venue, catering, A/V, travel costs.
 * Apply for internal university funds, external sponsorships and/or community grants e.g., [OSI](https://opensource.org/), [GitHub](https://github.com/sponsors), [Google Open Source](https://opensource.google/)
 
 ### Create a program that reflects OSPO goals
+
 * Use mailing lists, posters, social media, department announcements and partner networks to advertise the Call for Papers.
 * Invite keynote speakers and other key strategic partners who can discuss open source in research, education and industry.
 * Include hands-on sessions (workshops, sprints) to promote learning and engagement.
 * Spotlight student and faculty open source projects.
 
 ### Publicize the event
+
 * Use mailing lists, posters, social media, department announcements and partner networks to advertise the event itself.
 * Highlight opportunities to present, mentor or sponsor.
 
 ### Ensure Inclusivity and Accessibility
+
 * Provide hybrid/remote options, captioning and accessibility accommodations.
 * Follow a code of conduct and make it visible.
 
 ### Document and Archive the Event
+
 * Record sessions, collect slides and publish post-event write-ups.
 * Archive on OSPO web pages or repositories for future reference.
 
 ### Follow Up and Sustain Engagement
+
 * Gather feedback.
 * Send thanks to participants and sponsors.
 * Share outcomes publicly (blogs, newsletters, reports).
 * Build on the momentum for future events, projects or community activities.
-
 
 ## Resulting Context
 
@@ -119,14 +129,17 @@ There are a wide range of potential benefits to hosting a conference or event fo
 **Documentation and Legacy:** Conferences often result in articles, videos, and other artifacts that serve as resources and inspiration long after the event ends.
 
 ### Additional Learning from the Georgia Tech Open Source Program Office
+
 We also provide information about funding opportunities such as the [Pathways to Enable Open-Source Ecosystems (POSE)](https://www.nsf.gov/funding/opportunities/pose-pathways-enable-open-source-ecosystems) at our conferences. This is a great way to connect projects to funding programs that they may not be aware of.
 
 ### Additional Learning from the GW Open Source Program Office
+
 We used [Drupal](https://new.drupal.org/home) to host our conference pages and to manage our registration and CFP forms.  
 
-We also used [VolunteerSignup](https://volunteersignup.org/) which is free for non-commercial use (but may not be open source). 
+We also used [VolunteerSignup](https://volunteersignup.org/) which is free for non-commercial use (but may not be open source).
 
 ## Known Instances
+
 * [Georgia Tech Open Source Program Office](https://ospo.cc.gatech.edu/), Georgia Institute of Technology
 * [GW OSPO](https://ospo.gwu.edu/), George Washington University
 * [Johns Hopkins University OSPO](https://ospo.library.jhu.edu/), Sheridan Libraries, Johns Hopkins University
@@ -134,28 +147,30 @@ We also used [VolunteerSignup](https://volunteersignup.org/) which is free for n
 * [SnT Tech Transfer Office](https://www.uni.lu/snt-en/),  Université du Luxembourg
 * [UCSC OSPO](https://ucsc-ospo.github.io/), University of California, Santa Cruz, [UC OSPO Network](https://ucospo.net)
 * [VERSO OSPO](https://verso.w3.uvm.edu/), University of Vermont
-* [UW-Madison Open Source Program Office](https://ospo.wisc.edu/), Data Science Institute, University of Wisconsin-Madison 
-
+* [UW-Madison Open Source Program Office](https://ospo.wisc.edu/), Data Science Institute, University of Wisconsin-Madison
 
 ## References
 
 ### Links to conferences and high profile events hosted by Academic OSPOs
+
 * [GW OSCON](https://ospo.gwu.edu/oscon-2025)
 * [How Open Source is Fostering Innovation in AI event](https://ospo.wisc.edu/blog/2024/10/recording-available-of-ospo-innovate-week-event-how-open-source-is-fostering-innovation-in-ai/)
 * [Libre Office Conference 2024](https://conference.libreoffice.org/2024/)
 * [Open Source and Scientific Software Workshop](https://ospo.cc.gatech.edu/ospo-sse-workshop-2025/)
 * [Sustainable Software in Academia 2024](https://ssecenter.cc.gatech.edu/georgia-tech-scientific-software-2024-workshop/)
-* [University of California Open Summit (UC Open) 2025](https://ucospo.net/events/uc-open-4-2025/) 
+* [University of California Open Summit (UC Open) 2025](https://ucospo.net/events/uc-open-4-2025/)
 * [Johns Hopkins University, Free and Open Source Project Fund Summative Event](https://ospo.library.jhu.edu/services/free-and-open-source-software-project-fund-fossprof/fossprof-summative-event/)
 * [University of Vermont Open Science Summit](https://verso.w3.uvm.edu/data-open-science-summit/)
 
 ### Academic Conference Planning Resources
-* Ex Ordo’s [No-Panic Guide to Organising Successful Scholarly Events](https://www.exordo.com/blog/guide-to-academic-conferences) A practical guide aimed at simplifying the conference planning process. It includes tips on abstract management, scheduling, and leveraging technology to streamline event organization. 
-* Fourwaves’ [13 Steps to Plan a Great Research Conference](https://fourwaves.com/blog/how-to-plan-your-scientific-conference/) A step-by-step approach to organizing scientific conferences, covering everything from defining objectives and assembling a planning committee to budgeting and selecting keynote speakers. 
-* [Community Tool Box – Organizing a Conference](https://ctb.ku.edu/en/table-of-contents/structure/training-and-technical-assistance/conferences/main) Developed by the University of Kansas, this resource provides insights into the purpose of conferences, planning logistics, and strategies for effective execution, making it suitable for academic and community-focused events. 
-* [Wharton School’s Conference Planning Guide](https://mbastudentlife.wharton.upenn.edu/wp-content/uploads/2024/06/Conference-Planning-Guide.pdf) Targeted at student-led initiatives, this guide from the University of Pennsylvania offers practical advice on marketing, administrative tasks, and vendor coordination, making it a valuable resource for academic institutions. 
+
+* Ex Ordo’s [No-Panic Guide to Organising Successful Scholarly Events](https://www.exordo.com/blog/guide-to-academic-conferences) A practical guide aimed at simplifying the conference planning process. It includes tips on abstract management, scheduling, and leveraging technology to streamline event organization.
+* Fourwaves’ [13 Steps to Plan a Great Research Conference](https://fourwaves.com/blog/how-to-plan-your-scientific-conference/) A step-by-step approach to organizing scientific conferences, covering everything from defining objectives and assembling a planning committee to budgeting and selecting keynote speakers.
+* [Community Tool Box – Organizing a Conference](https://ctb.ku.edu/en/table-of-contents/structure/training-and-technical-assistance/conferences/main) Developed by the University of Kansas, this resource provides insights into the purpose of conferences, planning logistics, and strategies for effective execution, making it suitable for academic and community-focused events.
+* [Wharton School’s Conference Planning Guide](https://mbastudentlife.wharton.upenn.edu/wp-content/uploads/2024/06/Conference-Planning-Guide.pdf) Targeted at student-led initiatives, this guide from the University of Pennsylvania offers practical advice on marketing, administrative tasks, and vendor coordination, making it a valuable resource for academic institutions.
 
 ### Related Patterns
+
 * [Co-hosting student events](./cohosting-student-events.md)
 * [Facilitate connections at Open Source Conferences](./facilitate-connections-at-open-source-conferences.md)
 * [Informal OSPO focus group sessions at Open Source Events](./informal-ospo-focus-groups-at-open-source-events.md)
@@ -166,20 +181,21 @@ We also used [VolunteerSignup](https://volunteersignup.org/) which is free for n
 * [Student Showcase Sessions at OSPO Events](./student-showcase-sessions-at-ospo-events.md)
 
 ## Contributors & Acknowledgement
+
 In alphabetical order:
 
-* Allison Kittinger, University of Wisconsin-Madison, https://orcid.org/0000-0002-3104-5995
+* Allison Kittinger, University of Wisconsin-Madison, <https://orcid.org/0000-0002-3104-5995>
 * Bethany Philbrick, University of Wisconsin-Madison
-* Bill Branan, Johns Hopkins University, https://orcid.org/0000-0002-4735-6624
-* Ciara Flanagan, https://orcid.org/0009-0005-3153-7673
-* David Lippert, George Washington University, https://orcid.org/0009-0003-6444-9595
-* Emily Lovell, University of California Santa Cruz, https://orcid.org/0000-0001-5531-5956
-* Fang Liu, Georgia Institute of Technology, https://orcid.org/0000-0002-3383-2191 
+* Bill Branan, Johns Hopkins University, <https://orcid.org/0000-0002-4735-6624>
+* Ciara Flanagan, <https://orcid.org/0009-0005-3153-7673>
+* David Lippert, George Washington University, <https://orcid.org/0009-0003-6444-9595>
+* Emily Lovell, University of California Santa Cruz, <https://orcid.org/0000-0001-5531-5956>
+* Fang Liu, Georgia Institute of Technology, <https://orcid.org/0000-0002-3383-2191>
 * Jacek Plucinski,  Université du Luxembourg
-* Jeff Young, Georgia Institute of Technology, https://orcid.org/0000-0001-9841-4057
-* Kendall Fortney, University of Vermont, https://orcid.org/0009-0006-3898-0771
+* Jeff Young, Georgia Institute of Technology, <https://orcid.org/0000-0001-9841-4057>
+* Kendall Fortney, University of Vermont, <https://orcid.org/0009-0006-3898-0771>
 * Laura Langdon, University of California Davis
-* Lorena Barba, George Washington University, https://orcid.org/0000-0001-5812-2711
-* Megan Forbes, Johns Hopkins University, https://orcid.org/0000-0002-2611-1441
-* Sayeed Choudhury, Carnegie Mellon University, https://orcid.org/0000-0003-2891-0543
-* Stephanie Lieggi, University of California Santa Cruz, https://orcid.org/0009-0000-5647-6540
+* Lorena Barba, George Washington University, <https://orcid.org/0000-0001-5812-2711>
+* Megan Forbes, Johns Hopkins University, <https://orcid.org/0000-0002-2611-1441>
+* Sayeed Choudhury, Carnegie Mellon University, <https://orcid.org/0000-0003-2891-0543>
+* Stephanie Lieggi, University of California Santa Cruz, <https://orcid.org/0009-0000-5647-6540>

--- a/individual-consultations-office-hours.md
+++ b/individual-consultations-office-hours.md
@@ -43,7 +43,7 @@ An OSPO with the resources/capacity to offer one-to-one consultations and any re
 
 ## Forces
 
-Students and researchers do not know how or where to access the information they need. 
+Students and researchers do not know how or where to access the information they need.
 
 OSPO staff have the capacity/availability to meet for consultations and to provide follow-up support.
 
@@ -65,15 +65,19 @@ This can be offered through a number of different channels:
 Research teams and projects benefit from personalized guidance along with referrals to complementary university support services.
 
 ### Additional Learning from Carnegie Mellon University OSPO
+
 We use this [consultation template](https://docs.google.com/presentation/d/1ybyObRt8XOlrjK-CgCXBPImryWV-b4M9_OIfyAbUwo8/edit#slide=id.g2c709938643_0_8) to guide the conversation with projects and to assess their needs.
 
 ### Additional Learning from Georgia Tech OSPO
+
 We support [POSE](https://www.nsf.gov/funding/opportunities/pose-pathways-enable-open-source-ecosystems) proposal development with office hours.
 
 ### Additional Learning from University of California Santa Cruz OSPO
+
 We meet with projects to offer advice and support as needed. This is often a one-time call but sometimes grows into grant proposals or longer collaborations.
 
 ### Additional Learning from University of Vermont VERSO OSPO
+
 Most of our consultations come from internal referrals or the Tech Transfer Office.
 
 ## Known Instances
@@ -103,15 +107,15 @@ Most of our consultations come from internal referrals or the Tech Transfer Offi
 * [Consultation template for projects](https://www.google.com/url?q=https://docs.google.com/presentation/d/1ybyObRt8XOlrjK-CgCXBPImryWV-b4M9_OIfyAbUwo8/edit?usp%3Dsharing&sa=D&source=docs&ust=1746004597188190&usg=AOvVaw1juIFcUqNZPBiGZcWgF3eL) used by Carnegie Mellon University OSPO.
 
 ### Related Patterns
+
 [Template for 1:1 Campus Consultations](./template-for-1-1-campus-consultations.md)
 
 ## Contributors & Acknowledgement
 
-* David Lippert (The George Washington University), https://orcid.org/0009-0003-6444-9595
+* David Lippert (The George Washington University), <https://orcid.org/0009-0003-6444-9595>
 * Duane O'Brien - consulted on the design of the CMU OSPO project consultation template
-* Emily Lovell, University of California Santa Cruz, https://orcid.org/0000-0001-5531-5956
-* Kendall Fortney (University of Vermont), https://orcid.org/0009-0006-3898-0771
-* Tom Hughes (Carnegie Mellon University) https://orcid.org/0009-0008-7516-3687
-* Will Gearty (Syracuse University), https://orcid.org/0000-0003-0076-3262
-* Ciara Flanagan, https://orcid.org/0009-0005-3153-7673
-
+* Emily Lovell, University of California Santa Cruz, <https://orcid.org/0000-0001-5531-5956>
+* Kendall Fortney (University of Vermont), <https://orcid.org/0009-0006-3898-0771>
+* Tom Hughes (Carnegie Mellon University) <https://orcid.org/0009-0008-7516-3687>
+* Will Gearty (Syracuse University), <https://orcid.org/0000-0003-0076-3262>
+* Ciara Flanagan, <https://orcid.org/0009-0005-3153-7673>

--- a/informal-ospo-focus-groups-at-open-source-events.md
+++ b/informal-ospo-focus-groups-at-open-source-events.md
@@ -7,9 +7,11 @@ tags:
 # Informal OSPO focus group sessions at Open Source Events
 
 ## Pattern Summary
+
 Dedicate a conference session to gather feedback from academic community members about their awareness, needs and satisfaction with the OSPO’s services and initiatives.
 
 ## Problem / Challenge
+
 Academic OSPOs may have a limited understanding of their community's actual needs for a range of reasons:
 
 * Traditional surveys and formal feedback mechanisms often have low response rates and may not capture nuanced perspectives.
@@ -19,16 +21,18 @@ Academic OSPOs may have a limited understanding of their community's actual need
 
 ## Pattern Category
 
-- Building University OSS Community
-- Demonstrating value as an OSPO
-- Supporting OSS development  
+* Building University OSS Community
+* Demonstrating value as an OSPO
+* Supporting OSS development  
 
 ## Context
+
 A university with diverse departments of varying levels of OSS expertise and needs.
 
 An OSPO has been established.
 
 ## Forces
+
 Students, researchers and faculty do not know how or where to access information and support from the OSPO that they need.
 
 An event or conference has been organized by the OSPO.
@@ -36,14 +40,17 @@ An event or conference has been organized by the OSPO.
 Colleagues or volunteers are available to facilitate and take notes at a session about the OSPO.
 
 ## Solution
+
 Dedicate a session specifically designed as an informal focus group. Some suggested actions include:
 
 ### Session Design and Facilitation
-Frame the session as a community ‘conversation’ or ‘forum’  to emphasise the informal and open nature of the session. 
+
+Frame the session as a community ‘conversation’ or ‘forum’  to emphasise the informal and open nature of the session.
 
 Use neutral facilitators (i.e., not direct OSPO staff) where possible to encourage honest feedback.
 
 Depending on numbers, different approaches can be used:
+
 * Interactive formats like small group discussions, world café style rotations, or facilitated roundtables.
 * Multiple conversation stations focusing on different aspects (awareness, current services, unmet needs, barriers).
 * Start with broad, open-ended questions before diving into specific services.
@@ -51,13 +58,15 @@ Depending on numbers, different approaches can be used:
 * Mix individual reflection time with group discussion.
 
 ### Data Collection
+
 * One potential challenge may be the self-selection bias of attendees. Collect simple demographic data (faculty/staff/student status, school affiliation, experience level) to contextualize feedback and identify themes from different cohorts.
 * Use visual methods like sticky notes, idea boards, or digital collaboration tools.
 * Capture themes and patterns rather than individual attributions.
 * Have note-takers focus on recurring themes and surprising insights.
 
-### Key questions for the focus group:
-Consider important, relevant information that your OSPO needs from the community. This may relate to the state of open source in the institution or the OSPO itself. Sample questions are below: 
+### Key questions for the focus group
+
+Consider important, relevant information that your OSPO needs from the community. This may relate to the state of open source in the institution or the OSPO itself. Sample questions are below:
 
 * What open source challenges are you currently facing?
 * What support would be most valuable to your work?
@@ -66,30 +75,36 @@ Consider important, relevant information that your OSPO needs from the community
 * How did you hear about the Open Source Program Office?
 
 ### Other Considerations
+
 * If possible, plan for 90-120 minutes to allow for meaningful discussion.
 * Consider scheduling during prime conference time to maximize attendance.
 * Follow up with participants through surveys or individual conversations.
 * Share aggregated insights with the community to demonstrate impact.
 
 ## Resulting Context
+
 The informal focus group enables authentic exchange between the OSPO and the wider academy community.
 
-Community members have a valuable space to share honest feedback about open source within the institution and OSPO services while the OSPO gains nuanced insights from the community that will inform future planning and activities. 
+Community members have a valuable space to share honest feedback about open source within the institution and OSPO services while the OSPO gains nuanced insights from the community that will inform future planning and activities.
 
 Feedback may also demonstrate the positive impact that the OSPO is having with different cohorts on campus.
 
 ### Additional learning from the University of California OSPO Network
-Instead of a ‘Closing Remarks’ session at the end of our conference, we facilitated a ‘Closing Directed Discussion' where we prompted conversations about what the OSPO could do for the university. 
 
-Attendees had had two days of listening to us talking about things so they had lots of ‘percolation time’. We found that we’re either planning or in the process of setting up about 80% of the supports that people said they wanted. The other 20% are new ideas that will inform what we do next. 
+Instead of a ‘Closing Remarks’ session at the end of our conference, we facilitated a ‘Closing Directed Discussion' where we prompted conversations about what the OSPO could do for the university.
+
+Attendees had had two days of listening to us talking about things so they had lots of ‘percolation time’. We found that we’re either planning or in the process of setting up about 80% of the supports that people said they wanted. The other 20% are new ideas that will inform what we do next.
 
 ## Known Instances
+
 * [UC Santa Cruz OSPO](https://ucsc-ospo.github.io/), University of California Santa Cruz, [University of California OSPO Network](https://ucospo.net/)
 
 ## References
+
 [UC Open 2025](https://ucospo.net/events/uc-open-4-2025/) - scroll down the agenda for ‘How can we help? Academic OSPOs making an impact at UC’'
 
 ### Related patterns
+
 * [Co-hosting student events](./cohosting-student-events.md)
 * [Facilitate connections at Open Source Conferences](./facilitate-connections-at-open-source-conferences.md)
 * [Host an Open Source Conference](./host-an-open-source-conference.md)
@@ -99,7 +114,9 @@ Attendees had had two days of listening to us talking about things so they had l
 * [Student Showcase Sessions at OSPO Events](./student-showcase-sessions-at-ospo-events.md)
 
 ## Contributors & Acknowledgement
+
 In alphabetical order
-* Ciara Flanagan, https://orcid.org/0009-0005-3153-7673
-* Emily Lovell, University of California Santa Cruz, https://orcid.org/0000-0001-5531-5956
-* Stephanie Lieggi, University of California Santa Cruz, https://orcid.org/0009-0000-5647-6540
+
+* Ciara Flanagan, <https://orcid.org/0009-0005-3153-7673>
+* Emily Lovell, University of California Santa Cruz, <https://orcid.org/0000-0001-5531-5956>
+* Stephanie Lieggi, University of California Santa Cruz, <https://orcid.org/0009-0000-5647-6540>

--- a/integrating-oss-into-institutional-software-pathways.md
+++ b/integrating-oss-into-institutional-software-pathways.md
@@ -4,7 +4,7 @@ tags:
   - Promoting Best Practices
   - Working with Tech Transfer / External Partners
 ---
-# Integrating OSS into Institutional Software Pathways 
+# Integrating OSS into Institutional Software Pathways
 
 ## Pattern Summary
 
@@ -15,49 +15,53 @@ Consult with researchers, faculty and staff about open source software (OSS) to 
 * Researchers are often unaware of the institutional context their projects are operating in, the value of open source software (OSS) and how their projects may be impacted by decisions taken at earlier stages of development.
 * Colleagues in start-up, spin-off and Technology Transfer Offices (TTOs) may also lack crucial knowledge about open source software in comparison to proprietary software.
 
-
 ## Pattern Category
 
 Below is a list of common categories of academic OSPO activities \- please choose which apply:
 
-- Advocacy, Governance & Policy
-- Promoting Best Practices
-- Working with Tech Transfer / External Partners  
-   
+* Advocacy, Governance & Policy
+* Promoting Best Practices
+* Working with Tech Transfer / External Partners  
+
 ## Context
 
 A university committed to research, teaching, and the transfer of knowledge and technology with diverse departments of varying levels of OSS expertise and needs.
-An OSPO or staff member that is resourced to conduct a stakeholder consultation and to develop outputs based on the needs identified. 
+An OSPO or staff member that is resourced to conduct a stakeholder consultation and to develop outputs based on the needs identified.
 
 ## Forces
 
 Researchers are experiencing challenges in relation to the release and wider use of academic OSS in terms of OSS license management, compliance with institutional IP/OSS policies, aligning OSS license management with project goals and commercialization plans.
 TTOs are engaging at a later stage in development with researchers - after critical choices have been made about software release and licensing.
 TTOs may not be fully aware of the importance or value proposition of OSS.
-The OSPO or project lead has a working knowledge and relationship with TTO, contract, and/or spin-off colleagues. 
+The OSPO or project lead has a working knowledge and relationship with TTO, contract, and/or spin-off colleagues.
 
 ## Solution
 
 The solution below outlines some core activities to consider:
 
 ### Identify stakeholders
+
 Identify key staff that are tasked with advising or supporting the translation of academic OSS projects (e.g. Technology Transfer, research contract teams, spin-offs and start-up teams).
 Identify faculty, researchers, research software engineers and post-docs involved in OSS research and related activities.
 
 ### Outreach and promotion of consultation
-Organise individual or small group meetings with key staff members to identify pitfalls  and needs related to OSS that have emerged in their work. 
+
+Organise individual or small group meetings with key staff members to identify pitfalls  and needs related to OSS that have emerged in their work.
 Seek more extensive feedback from  faculty and researchers by organizing small group meetings; contact Department heads in the first instance to organize support with distributing meeting invites.
 
 ### Consultation process
 
 #### Designing questions
-Questions for staff may differ from faculty and researchers. 
+
+Questions for staff may differ from faculty and researchers.
 Questions for staff in TTOs and related teams are likely to focus on:
+
 * The recurrent issues that they encounter.
 * When these problems typically arise.
 * The advice they currently provide on academic OSS.
 
 Questions for faculty and students may need to capture:
+
 * Their areas of work.
 * What they may have misunderstood or ignored about open source in the initial research and development phases.
 * The impact of common pitfalls on the release, management, commercialization or translation of their projects.
@@ -65,17 +69,21 @@ Questions for faculty and students may need to capture:
 * What type of materials/supports they would benefit from in relation to these issues and how best to promote them to a wider audience within the institution.
 
 #### Initial consultation phase
+
 Organise meetings with each cohort to understand the common challenges and their understanding of software pathways within the institution.
 
 #### Develop educational resources
+
 * Based on learning, create a draft resource that addresses the identified knowledge gaps and common pitfalls. This may include:
 * Signposting contact points
 * A process map or flowchart relating to software pathways and key decision points for all stakeholders.
 
 #### Follow up consultation
+
 Meet with stakeholders for an internal review of the educational resources developed. Some additional work may be necessary.
 
 #### Promotion of resources
+
 Use learning from consultations to promote resources or services as widely as possible.
 
 ## Resulting Context
@@ -83,8 +91,9 @@ Use learning from consultations to promote resources or services as widely as po
 The intended outcome is that all stakeholders have a clearer and common understanding of how academic OSS can be integrated into the common software pathways within their university.
 
 ### Additional learning from the ETH Zürich
-We decided to use a clear infographic to capture the pathways for release and management of both OSS and proprietary software. 
-Our TTO colleagues found this process particularly useful and we have been able to use this process to communicate the key contact points for faculty and students when they have questions or need support. 
+
+We decided to use a clear infographic to capture the pathways for release and management of both OSS and proprietary software.
+Our TTO colleagues found this process particularly useful and we have been able to use this process to communicate the key contact points for faculty and students when they have questions or need support.
 
 ## Known Instances
 
@@ -94,5 +103,5 @@ Our TTO colleagues found this process particularly useful and we have been able 
 
 ## Contributors & Acknowledgement
 
-Ying Wang, ETH Zürich 
-Ciara Flanagan, https://orcid.org/0009-0005-3153-7673
+Ying Wang, ETH Zürich
+Ciara Flanagan, <https://orcid.org/0009-0005-3153-7673>

--- a/lower-the-barriers-to-entry-for-student-hackathons.md
+++ b/lower-the-barriers-to-entry-for-student-hackathons.md
@@ -9,73 +9,87 @@ tags:
 # Lower the barriers to entry for Student Hackathons
 
 ## Pattern Summary
+
 Offer pre-event training for participants and mentors to ensure that students of *all skill levels* can participate meaningfully in a hackathon.
 
 ## Problem / Challenge
+
 Hackathons risk becoming exclusive to students who already have advanced technical skills. This limits both the diversity and number of participants who can meaningfully contribute to hackathons.
 
-Compared to PhD students or more experienced peers, less experienced participants (e.g. undergraduates or students new to a particular tool or language) may believe they don’t have the necessary skills or knowledge to participate in a hackathon. 
+Compared to PhD students or more experienced peers, less experienced participants (e.g. undergraduates or students new to a particular tool or language) may believe they don’t have the necessary skills or knowledge to participate in a hackathon.
 
 Mentors recruited from industry may be highly technically skilled but unfamiliar with how to work effectively with students at varying levels of experience. Without preparation, their mentorship may unintentionally favour advanced participants or fail to meet the needs of those who need more support.
 
 ## Pattern Category
+
 - Community Building
 - Diversity, Equity, Inclusion
 - Education & Skills
 - Promoting Best Practices
 
 ## Context
-A university OSPO is organizing or co-organizing a student hackathon. 
 
-The event is intended to be open to students across different programs and levels of experience - from undergraduates to postgraduates. 
+A university OSPO is organizing or co-organizing a student hackathon.
 
-Some mentors are being recruited from industry rather than academia. 
+The event is intended to be open to students across different programs and levels of experience - from undergraduates to postgraduates.
+
+Some mentors are being recruited from industry rather than academia.
 
 ## Forces
+
 Staff have the capacity to organize and/or deliver pre-training in advance of the event itself.
 
 ## Solution
+
 Design and deliver a pre-event preparation programme that addresses the needs of both participants and mentors before the hackathon begins.
 
 The solution below outlines some core activities to consider:
 
 ### Offer *optional* technical pre-training for participants
+
 - Identify the core tools and skills that participants will need to engage with the hackathon challenges. Examples of relevant training include introductions to GitHub, Python or Jupyter Notebooks.
-- Offer short, accessible training sessions in advance of the event that allow less experienced students to get up to speed. 
+- Offer short, accessible training sessions in advance of the event that allow less experienced students to get up to speed.
 - Framing these sessions as 'optional but useful' encourages participation without implying that students who attend are less capable.  
 
 ### Deliver mentor training ahead of the event
-- Recruit mentors with enough lead time to provide them with a dedicated preparation session before the hackathon. 
-- Depending on the event’s theme, training may explore cover how to work effectively with students at different skill levels and what to expect from participants who are newer to the domain. 
+
+- Recruit mentors with enough lead time to provide them with a dedicated preparation session before the hackathon.
+- Depending on the event’s theme, training may explore cover how to work effectively with students at different skill levels and what to expect from participants who are newer to the domain.
 
 This is particularly important for industry mentors who may not have recent experience working in an academic or educational setting.
- 
+
 ### Communicate the multi-skill-level ethos clearly
-Make it explicit in all event communications that the hackathon is designed for multiple skill levels and that support is available. 
+
+Make it explicit in all event communications that the hackathon is designed for multiple skill levels and that support is available.
 
 This sets expectations for both participants and mentors and helps to create an environment where less experienced students feel genuinely welcome.
 
 ### During the event
-Where possible, provide a range of contribution opportunities for beginner-friendly issues (e.g. documentation, simple bug fixes). 
+
+Where possible, provide a range of contribution opportunities for beginner-friendly issues (e.g. documentation, simple bug fixes).
 
 ## Resulting Context
+
 Pre-event training demonstrates that the OSPO is invested in participant success and models the importance of inclusive participation in open source.
 
 There is greater opportunity for students of all skill levels to participate meaningfully and learn about open source practices.
 
-Mentor preparation improves the quality of support available on the day and reduces the risk of less experienced participants being overlooked. 
+Mentor preparation improves the quality of support available on the day and reduces the risk of less experienced participants being overlooked.
 
 ### Additional Learning from UT-OSPO, University of Texas at Austin
-We encourage multiple skill levels at our hackathons. We offer pre-training to support this. At a recent hackathon, we delivered training on how to get started with GitHub, and also on Jupyter Notebooks and Python. 
+
+We encourage multiple skill levels at our hackathons. We offer pre-training to support this. At a recent hackathon, we delivered training on how to get started with GitHub, and also on Jupyter Notebooks and Python.
 
 We also provide mentor training beforehand. Some of our mentors come from industry and the training focuses on how to work with students.
 
 ## Known Instances
+
 - [The University of Texas OSPO (UT-OSPO)](https://opensource.utexas.edu/), University of Texas at Austin
 
 ## References
 
 ### Related Patterns
+
 - [Organize an Open Source Hackathon](organize-an-open-source-hackathon.md)
 - [Design a Collaborative Open Source Hackathon](design-a-collaborative-open-source-hackathon.md)
 - [Enable Student-led Hackathons](enable-student-led-hackathons.md)
@@ -84,9 +98,10 @@ We also provide mentor training beforehand. Some of our mentors come from indust
 - [Collaborate with External Partners on Open Source Hackathons](collaborate-with-external-partners-on-open-source-hackathons.md)
 
 ## Contributors & Acknowledgement
+
 - Angela Newell, University of Texas at Austin
-- Ciara Flanagan, https://orcid.org/0009-0005-3153-7673
-- David Lippert, George Washington University, https://orcid.org/0009-0003-6444-9595
-- Emily Lovell, University of California Santa Cruz, https://orcid.org/0000-0001-5531-5956
+- Ciara Flanagan, <https://orcid.org/0009-0005-3153-7673>
+- David Lippert, George Washington University, <https://orcid.org/0009-0003-6444-9595>
+- Emily Lovell, University of California Santa Cruz, <https://orcid.org/0000-0001-5531-5956>
 - Laura Langdon, University of California, Davis
-- Tom Hughes, Carnegie Mellon University, https://orcid.org/0009-0008-7516-3687
+- Tom Hughes, Carnegie Mellon University, <https://orcid.org/0009-0008-7516-3687>

--- a/lunch-and-learn.md
+++ b/lunch-and-learn.md
@@ -20,16 +20,16 @@ OSPO is tasked with developing a response to a new funding requirement across th
 
 ## Context
 
-* A university with a large and diverse research and instructional cohort.
-* New Government Directives or funding programs issue requirements that impact many (or all) Departments within a university.   
-* The response required may vary according to the discipline.
-* There is a lack of coordination across the university, with individual faculty finding solutions on their own. 
+- A university with a large and diverse research and instructional cohort.
+- New Government Directives or funding programs issue requirements that impact many (or all) Departments within a university.
+- The response required may vary according to the discipline.
+- There is a lack of coordination across the university, with individual faculty finding solutions on their own.
 
 ## Forces
 
-* Requirements are driven by Government Directives and/or new funding requirements.
-* There is a concern that faculty may not be fully compliant with the new requirements.
-* It is unclear how new compliance requirements relate to good practice standards in relation to open source software, open source projects and open science.
+- Requirements are driven by Government Directives and/or new funding requirements.
+- There is a concern that faculty may not be fully compliant with the new requirements.
+- It is unclear how new compliance requirements relate to good practice standards in relation to open source software, open source projects and open science.
 
 ## Solution
 
@@ -39,21 +39,21 @@ The solution below outlines basic core activities to consider:
 
 ### Research
 
-* Conduct interviews with selected faculty and administrative staff.  
-* Review how the new requirement affects a sample of disciplines.  
-* Review how other universities are responding to the requirement.
+- Conduct interviews with selected faculty and administrative staff.  
+- Review how the new requirement affects a sample of disciplines.  
+- Review how other universities are responding to the requirement.
 
 ### Lunch-and-Learn event
 
-* Invite faculty and relevant administration to the event.   
-* At the event, present findings and share best practice guidelines.  
-* Faculty members will also give short presentations on their needs and the solutions they’ve adopted.
+- Invite faculty and relevant administration to the event.
+- At the event, present findings and share best practice guidelines.  
+- Faculty members will also give short presentations on their needs and the solutions they’ve adopted.
 
 ## Resulting Context
 
-Faculty have shared learning about potential solutions across a range of disciplines. 
+Faculty have shared learning about potential solutions across a range of disciplines.
 
-A network of key faculty and staff can be developed further to share learning and problem-solve in the future. 
+A network of key faculty and staff can be developed further to share learning and problem-solve in the future.
 
 A report capturing key learning about the requirement, compliance and good practice can be circulated widely across the university.
 
@@ -61,7 +61,7 @@ A report capturing key learning about the requirement, compliance and good pract
 
 In our case, the OSPO was tasked with supporting the development of comprehensive data management and public access guidelines (in response to the [Nelson Memo](https://bidenwhitehouse.archives.gov/ostp/news-updates/2022/08/25/ostp-issues-guidance-to-make-federally-funded-research-freely-available-without-delay/)).
 
-Interviews with faculty and sample review of grants and what other universities are doing illustrated the scope of the problem, potential complications and some potential solutions. 
+Interviews with faculty and sample review of grants and what other universities are doing illustrated the scope of the problem, potential complications and some potential solutions.
 
 The faculty luncheon was a success. Attendees found it extremely useful to hear what type of data other faculty were producing, and what they were doing to share it. They also really enjoyed the opportunity to communicate with others across disciplines and with research and library administrators. There was a strong desire to hold more such events in the future. The faculty’s slides were compiled into a single slide deck, which can be accessed from the OSPO website.
 
@@ -69,8 +69,8 @@ Our investigation and the faculty luncheon resulted in a formal report from the 
 
 ## Known Instances
 
-* [Syracuse University OSPO](https://opensource.syracuse.edu/), Syracuse University
-* [GW Coders Lunch & Learn Series](https://gwcoders.github.io/studyGroup/#events), George Washington University - The GW OSPO partners with the existing GW Coders group to increase the series from bi-weekly to weekly while adding an open source and collaborative development focus to the group.
+- [Syracuse University OSPO](https://opensource.syracuse.edu/), Syracuse University
+- [GW Coders Lunch & Learn Series](https://gwcoders.github.io/studyGroup/#events), George Washington University - The GW OSPO partners with the existing GW Coders group to increase the series from bi-weekly to weekly while adding an open source and collaborative development focus to the group.
 
 ## References
 

--- a/maintainers-and-contributors-roundtable.md
+++ b/maintainers-and-contributors-roundtable.md
@@ -9,22 +9,23 @@ tags:
 
 ## Pattern Summary
 
-Convene a community of practice consisting of students and staff who are actively maintaining or contributing to university open source software projects in the research enterprise. 
+Convene a community of practice consisting of students and staff who are actively maintaining or contributing to university open source software projects in the research enterprise.
 
 ## Problem / Challenge
 
-Active open source software maintainers and contributors are often scattered across laboratories and departments on university campuses. 
+Active open source software maintainers and contributors are often scattered across laboratories and departments on university campuses.
 
-In many cases, maintainers find themselves in isolated roles without a way of learning about each other’s work or a means of connecting. 
+In many cases, maintainers find themselves in isolated roles without a way of learning about each other’s work or a means of connecting.
 
-A certain proportion of maintainers are experts in their research field but not in open source software development and lack the awareness of where and how to find the information they need. 
+A certain proportion of maintainers are experts in their research field but not in open source software development and lack the awareness of where and how to find the information they need.
 
 ## Pattern Category
+
 - Community Building
 - Education & Skills
 - Open Source Discovery
 - Promoting Best Practices
-   
+
 ## Context
 
 A research university creating large volumes of research outputs across every discipline.
@@ -33,7 +34,7 @@ A Research Software Engineer (RSE) or equivalent group does not currently exist 
 
 ## Forces
 
-There is a growing or established interest in creating a community space for active maintainers or contributors to open source software. 
+There is a growing or established interest in creating a community space for active maintainers or contributors to open source software.
 
 Students and staff who are actively maintaining or contributing to university open source software projects want to connect with peers in similar roles and access advice.
 
@@ -49,45 +50,50 @@ Convene a regular community of practice to facilitate the sharing of project act
 
 The community of practice or ‘roundtable’ may be promoted in a number of ways, including:
 
-* Sourcing maintainer and core contributor of open source projects through direct communications with the Principal Investigators (PIs) of labs.
+- Sourcing maintainer and core contributor of open source projects through direct communications with the Principal Investigators (PIs) of labs.
 
-* Inviting new members by promoting the community on our OSPO mailing list.
+- Inviting new members by promoting the community on our OSPO mailing list.
 
-* Advertising the meetings and sharing the rotating list of most commonly discussed topics on the OSPO website to give prospective members a sense of what may be discussed at any one meeting.
+- Advertising the meetings and sharing the rotating list of most commonly discussed topics on the OSPO website to give prospective members a sense of what may be discussed at any one meeting.
 
-* Requesting membership to provide referrals.
+- Requesting membership to provide referrals.
 
 ### Meeting Preparation
 
-* Typical meeting preparation involves room booking and food orders (if budgets are available). 
-* Plan for a relevant topic/theme for each meeting that will engage the community members.
-* Where possible, contact community members whose expertise and interests match the topic.
+- Typical meeting preparation involves room booking and food orders (if budgets are available).
+- Plan for a relevant topic/theme for each meeting that will engage the community members.
+- Where possible, contact community members whose expertise and interests match the topic.
 
 ### Facilitating meetings
-* Host on-site meetings once a month with a hybrid option for remote members.
-* Organize each meeting around one core topic/theme or specific project and advertise the topic in advance.
-* Typically, a member of the OSPO should take on the role of facilitator.
-* In order to encourage a safe and enjoyable learning space, the tone of the meeting can be casual and conversational.
-* The meetings should also have a code of conduct or established norms such as [Chatham House Rule](https://www.chathamhouse.org/about-us/chatham-house-rule) that encourage participants to share their thoughts freely.
+
+- Host on-site meetings once a month with a hybrid option for remote members.
+- Organize each meeting around one core topic/theme or specific project and advertise the topic in advance.
+- Typically, a member of the OSPO should take on the role of facilitator.
+- In order to encourage a safe and enjoyable learning space, the tone of the meeting can be casual and conversational.
+- The meetings should also have a code of conduct or established norms such as [Chatham House Rule](https://www.chathamhouse.org/about-us/chatham-house-rule) that encourage participants to share their thoughts freely.
 
 ## Resulting Context
 
 ### Benefits for participants
-Creating a dedicated on-campus space for open source software maintainers and contributors fosters an essential sense of community and **alleviates the isolation many have previously experienced in their roles**. 
+
+Creating a dedicated on-campus space for open source software maintainers and contributors fosters an essential sense of community and **alleviates the isolation many have previously experienced in their roles**.
 
 Encouraging developers, coding leads, research scientists, and similar stakeholders to build relationships also instills a **supportive network that generates collective problem-solving**.
 
-This newfound connection encourages **knowledge and skills sharing**. 
+This newfound connection encourages **knowledge and skills sharing**.
 
 ### Benefits for the OSPO
-Hosting a community of practice yields a number of positive outcomes for the OSPO: 
-* Stronger relationships with open source maintainers and contributors on campus. 
-* Greater engagement from community of practice members in other OSPO initiatives (e.g. workshops, consultations, mentorship).
-* Deeper insights into specific needs and pain points of this cohort.
-* Increased opportunity to discover new open source projects on campus.
-* Potential to amplify the impact of open source projects through the facilitation of knowledge sharing and collaboration.  
+
+Hosting a community of practice yields a number of positive outcomes for the OSPO:
+
+- Stronger relationships with open source maintainers and contributors on campus.
+- Greater engagement from community of practice members in other OSPO initiatives (e.g. workshops, consultations, mentorship).
+- Deeper insights into specific needs and pain points of this cohort.
+- Increased opportunity to discover new open source projects on campus.
+- Potential to amplify the impact of open source projects through the facilitation of knowledge sharing and collaboration.  
 
 ### Additional Learning from OpenSource@Stanford
+
 Open source is both a technical and social system so we leverage that by creating spaces for people to learn from each other.
 
 Based on Lave & Wenger's "Situated Learning," we interpret a community of practice as a vibrant learning community where members collectively work towards gaining knowledge and competencies connected to their shared interests.
@@ -116,31 +122,30 @@ Our growing M&CR membership also facilitated discovery of other open source proj
 
 A particularly valuable result is that members continue to stay in touch outside of monthly meetings. Having a dedicated communication channel (e.g. dedicated Slack channel, mailing list) for members to continue to share ideas, solicit advice, and build connection has made the monthly meeting cadence feel appropriate since there are many asynchronous touchpoints between meetings. We also maintain an active alumni group (composed of former members who have moved on to other academic or industry positions) and welcome them at meetings and on Slack.
 
-In line with our aim to create a safe space for members, we do not invite faculty PI's to monthly meetings, unless there is a special session. In these cases, we notify members in advance. We based this on a simple idea that people behave differently when the "boss" is in the room and we’ve received positive feedback from members about this choice. 
+In line with our aim to create a safe space for members, we do not invite faculty PI's to monthly meetings, unless there is a special session. In these cases, we notify members in advance. We based this on a simple idea that people behave differently when the "boss" is in the room and we’ve received positive feedback from members about this choice.
 
 However, there is a possibility for convening an alternative community of practice that allows faculty members in the case where the faculty member *is* the maintainer of the project and would benefit from a similar community of other project maintainers.
 
-
 ## Known Instances
 
-* [OpenSource@Stanford](https://opensource.stanford.edu/), Stanford Data Science Center for Open and Reproducible Science (CORES), Leland Stanford Junior University
-* [UC OSPO Network](https://ucospo.net/), University of California
+- [OpenSource@Stanford](https://opensource.stanford.edu/), Stanford Data Science Center for Open and Reproducible Science (CORES), Leland Stanford Junior University
+- [UC OSPO Network](https://ucospo.net/), University of California
 
 ## References
 
-* [OpenSource@Stanford’s Maintainers & Contributors Roundtable](https://opensource.stanford.edu/programs/maintainers-contributors-roundtable)
-* [Highlights from the first UC Open Source Contributors & Maintainers Virtual Meetup](https://bids.berkeley.edu/news/building-bridges-highlights-inaugural-uc-open-source-meetup)
-* [OpenSource@Stanford’s Maintainers & Contributors Roundtable](https://www.youtube.com/watch?v=1tCLyTWbSbE) - CURIOSS Deep Dive with Francesca Vera and Ellianna Abrahams 
-* Lave, Jean, and Étienne Wenger-Trayner. *Situated Learning: Legitimate Peripheral Participation*. Cambridge University Press, 2020.
-* Brown, John Seely, et al. *The Social Life of Information*. Harvard Business Review Press, 2017. 
+- [OpenSource@Stanford’s Maintainers & Contributors Roundtable](https://opensource.stanford.edu/programs/maintainers-contributors-roundtable)
+- [Highlights from the first UC Open Source Contributors & Maintainers Virtual Meetup](https://bids.berkeley.edu/news/building-bridges-highlights-inaugural-uc-open-source-meetup)
+- [OpenSource@Stanford’s Maintainers & Contributors Roundtable](https://www.youtube.com/watch?v=1tCLyTWbSbE) - CURIOSS Deep Dive with Francesca Vera and Ellianna Abrahams
+- Lave, Jean, and Étienne Wenger-Trayner. *Situated Learning: Legitimate Peripheral Participation*. Cambridge University Press, 2020.
+- Brown, John Seely, et al. *The Social Life of Information*. Harvard Business Review Press, 2017.
 
 ### Related Patterns
 
-* [Open Source Catalog](./open-source-catalog.md)
-* [Set up an informal Communication Platform](./set-up-an-informal-communication-platform.md)
+- [Open Source Catalog](./open-source-catalog.md)
+- [Set up an informal Communication Platform](./set-up-an-informal-communication-platform.md)
 
 ## Contributors & Acknowledgement
 
-* Francesca Vera, Stanford University, https://orcid.org/0000-0001-8791-3854
-* Zach Chandler, Stanford University,  https://orcid.org/0000-0003-2402-9839
-* Ciara Flanagan https://orcid.org/0009-0005-3153-7673
+- Francesca Vera, Stanford University, <https://orcid.org/0000-0001-8791-3854>
+- Zach Chandler, Stanford University,  <https://orcid.org/0000-0003-2402-9839>
+- Ciara Flanagan <https://orcid.org/0009-0005-3153-7673>

--- a/onboarding-graduate-leads-for-open-source-internship-programs.md
+++ b/onboarding-graduate-leads-for-open-source-internship-programs.md
@@ -23,7 +23,7 @@ Establish a structured onboarding process for graduate students taking on team l
 
 - Education & Skills
 - Promoting Best Practices
-   
+
 ## Context
 
 - A research or teaching university.
@@ -44,7 +44,7 @@ Establish a structured onboarding process for graduate students taking on team l
 
 ## Solution
 
-Develop a structured pre-semester onboarding program for graduate leads that equips them with the technical, professional, and interpersonal skills they need to lead their teams effectively from the first day of class. 
+Develop a structured pre-semester onboarding program for graduate leads that equips them with the technical, professional, and interpersonal skills they need to lead their teams effectively from the first day of class.
 
 Key design considerations include:
 
@@ -54,11 +54,11 @@ Where possible, begin onboarding graduate leads before the semester starts. This
 
 ### Develop structured training materials and workshops
 
-Develop onboarding documentation specifically dedicated to the key skills and knowledge areas tech leads will need. 
+Develop onboarding documentation specifically dedicated to the key skills and knowledge areas tech leads will need.
 
 Onboarding should also explicitly address the shift in role and mindset required when moving from individual contributor to team lead.
 
-Where time allows, run dedicated onboarding workshops for incoming leads. 
+Where time allows, run dedicated onboarding workshops for incoming leads.
 
 Topics for onboarding materials or workshops may include:
 
@@ -73,17 +73,17 @@ Topics for onboarding materials or workshops may include:
 
 ### Documented processes and resources
 
-Provide leads with clear documentation of program processes, expectations, and standards. 
+Provide leads with clear documentation of program processes, expectations, and standards.
 
-This may include a handbook covering codes of conduct, communication norms, sprint structures, evaluation criteria, and escalation procedures. 
+This may include a handbook covering codes of conduct, communication norms, sprint structures, evaluation criteria, and escalation procedures.
 
 Well-documented processes reduce the cognitive load on leads and ensure consistency across teams.
 
 ### Ongoing support structures
 
-Onboarding should not end at the start of the semester. 
+Onboarding should not end at the start of the semester.
 
-Build in regular touchpoints between leads and program staff or faculty throughout the semester. 
+Build in regular touchpoints between leads and program staff or faculty throughout the semester.
 
 Create dedicated communication channels for OSPO staff to answer questions from leads.
 
@@ -107,9 +107,9 @@ Open Source with SLU developed the [Building Open Leadership Toolsets (BOLT)](ht
 
 The BOLT workshop covers the full range of skills that tech leads need, including open source community practices, product and project management, professional communication norms and the specific tools and processes used within the Open Source with SLU program. By the time the semester starts, leads are ready to onboard their teams immediately rather than spending the first weeks finding their feet.
 
-The transition from graduate student to tech lead is treated explicitly as a professional development milestone. 
+The transition from graduate student to tech lead is treated explicitly as a professional development milestone.
 
-We’ve also developed a dedicated handbook on mentoring for tech leads to support this transition, providing leads with a practical reference resource throughout the semester. 
+We’ve also developed a dedicated handbook on mentoring for tech leads to support this transition, providing leads with a practical reference resource throughout the semester.
 
 ### Additional Learning from the University of Vermont VERSO Open Source Program Office
 
@@ -138,9 +138,9 @@ A key insight from our experience is the importance of creating spaces where lea
 
 ## Contributors & Acknowledgement
 
-- Ciara Flanagan (CURIOSS),(https://orcid.org/0009-0005-3153-7673)
-- Daniel Shown (Saint Louis University), https://orcid.org/0009-0002-5716-8835
-- Kendall Fortney (University of Vermont), https://orcid.org/0009-0006-3898-0771
-- Jeffrey Young (OSPO@GT), https://orcid.org/0000-0001-9841-4057 
+- Ciara Flanagan (CURIOSS),(<https://orcid.org/0009-0005-3153-7673>)
+- Daniel Shown (Saint Louis University), <https://orcid.org/0009-0002-5716-8835>
+- Kendall Fortney (University of Vermont), <https://orcid.org/0009-0006-3898-0771>
+- Jeffrey Young (OSPO@GT), <https://orcid.org/0000-0001-9841-4057>
 
 A note on AI use: In addition to working from Deep Dive transcripts, capturing learning from our community discussions and other patterns from our members, this pattern was drafted with the help of AI. As a small organization, tools like this help us turn rich conversations into written resources without losing the ideas along the way. As always, there were plenty of human eyes reviewing, editing and improving the content before this pattern made it to publication. Thanks go to our community for the insights. If you do spot any errors, please let us know so we can correct them!

--- a/onboarding-students-for-open-source-internship-programs.md
+++ b/onboarding-students-for-open-source-internship-programs.md
@@ -23,7 +23,7 @@ Prepare incoming students with essential onboarding training that enables them t
 
 - Education & Skills
 - Promoting Best Practices
-   
+
 ## Context
 
 - A research or teaching university.
@@ -40,13 +40,13 @@ Students arrive with widely varying levels of prior experience in open source to
 
 The fixed duration of internship programs leaves little room for a slow onboarding process.
 
-Program staff and tech leads have limited capacity to provide individualised onboarding support to every student. 
+Program staff and tech leads have limited capacity to provide individualised onboarding support to every student.
 
 OSPO staff have limited time and capacity to deliver in-person training at scale.
 
 ## Solution
 
-Develop a structured onboarding process for incoming students that provides a common foundation of skills, knowledge and professional orientation before or at the start of the program. 
+Develop a structured onboarding process for incoming students that provides a common foundation of skills, knowledge and professional orientation before or at the start of the program.
 
 Onboarding should be designed to be scalable, welcoming and practical. It should model open source best practices through clear and openly available documentation.
 
@@ -56,13 +56,13 @@ Key design considerations include:
 
 ### Pre-program preparation
 
-Pre-program preparation reduces the time needed for onboarding once the program starts and allows students to begin contributing from the outset. Where possible, provide students with onboarding materials and resources before the program formally begins. 
+Pre-program preparation reduces the time needed for onboarding once the program starts and allows students to begin contributing from the outset. Where possible, provide students with onboarding materials and resources before the program formally begins.
 
 This may include introductory reading on open source practices, guidance on setting up their development environment and/or an overview of the program's tools, workflows, and communication norms.
 
 ### Structured onboarding activities
 
-Design a dedicated onboarding period at the start of the program that introduces students to the key skills, tools, and expectations they will need. 
+Design a dedicated onboarding period at the start of the program that introduces students to the key skills, tools, and expectations they will need.
 
 This should cover open source community norms and practices; the program's specific workflows and tools (e.g. version control, issue tracking, communication platforms); professional communication standards; and the structure and goals of the program itself.
 
@@ -70,9 +70,9 @@ Onboarding activities should be practical and hands-on wherever possible.
 
 ### Project and team orientation
 
-Ensure that students are introduced not only to the program as a whole but to their specific project and team. 
+Ensure that students are introduced not only to the program as a whole but to their specific project and team.
 
-This includes familiarising students with the project's codebase, history and goals. 
+This includes familiarising students with the project's codebase, history and goals.
 
 Introducing students to their tech lead, client and any relevant community members will help them understand how their contribution fits into the longer-term product vision.
 
@@ -84,9 +84,9 @@ Provide students with well-documented reference materials they can return to thr
 
 ### Ongoing support and check-ins
 
-Onboarding should not be treated as a one-off event. 
+Onboarding should not be treated as a one-off event.
 
-Build in regular check-ins between students and program staff or tech leads in the early weeks of the program to identify and address any gaps in understanding or confidence. 
+Build in regular check-ins between students and program staff or tech leads in the early weeks of the program to identify and address any gaps in understanding or confidence.
 
 Dedicated communication channels where students can ask questions and share challenges also help to extend the onboarding support throughout the program.
 
@@ -133,6 +133,6 @@ A key insight from our experience is that onboarding is most effective when it c
 
 ## Contributors & Acknowledgement
 
-- Ciara Flanagan (CURIOSS), https://orcid.org/0009-0005-3153-7673
-- Daniel Shown (Saint Louis University), https://orcid.org/0009-0002-5716-8835
-- Kendall Fortney (University of Vermont), https://orcid.org/0009-0006-3898-0771
+- Ciara Flanagan (CURIOSS), <https://orcid.org/0009-0005-3153-7673>
+- Daniel Shown (Saint Louis University), <https://orcid.org/0009-0002-5716-8835>
+- Kendall Fortney (University of Vermont), <https://orcid.org/0009-0006-3898-0771>

--- a/open-project-management-using-github-projects.md
+++ b/open-project-management-using-github-projects.md
@@ -4,7 +4,7 @@ tags:
   - Promoting Best Practices
   - Tools & Infrastructure
 ---
-# Open Project Managment Using Github Projects 
+# Open Project Managment Using Github Projects
 
 ## Pattern Summary
 
@@ -15,65 +15,74 @@ Utilizing Github Projects to publicly and transparently organize and manage OSPO
 Academic OSPOs with a small staff or team of student workers face similar challenges to other organizations in managing their tasking and resources, but they face the additional challenge of trying to walk the walk of being open and transparent.  Extending open source best practices beyond software to open project management is an aspirational attempt at experiential learning where even non technical staff can learn git and GitHub as their team manages issues in the open.
 
 ## Pattern Category
+
 - Community Building
 - Promoting Best Practices
 - Tools & Infrastructure
-   
+
 ## Context
+
 This pattern applies to university-based OSPOs that use GitHub as a primary collaboration platform and coordinate work across multiple contributors, such as staff, faculty, and student workers. It is very relevant for OSPOs managing recurring activities, including events, training, consultations, and open source projects.
 
 ## Forces
-+ **Transparency vs. sensitivity:** OSPOs aim to work openly, but some tasks involve sensitive information that cannot be fully public.
-+ **Learning curve:** GitHub Projects requires contributors to learn a new tool, which can be challenging in academic OSPOs where students and short-term contributors rotate frequently.
-+ **Timely updates:** Project boards are only useful if issues are consistently updated, which can be difficult to maintain.
-+ **Tracking sub-issues:** Many OSPO tasks involve subtasks, which can be difficult to represent clearly without added structure.
-+ **Tool integration gaps:** Limited integration with tools like Slack, Gmail, or Logseq can cause work to be discussed or tracked outside GitHub, reducing visibility.
+
+- **Transparency vs. sensitivity:** OSPOs aim to work openly, but some tasks involve sensitive information that cannot be fully public.
+- **Learning curve:** GitHub Projects requires contributors to learn a new tool, which can be challenging in academic OSPOs where students and short-term contributors rotate frequently.
+- **Timely updates:** Project boards are only useful if issues are consistently updated, which can be difficult to maintain.
+- **Tracking sub-issues:** Many OSPO tasks involve subtasks, which can be difficult to represent clearly without added structure.
+- **Tool integration gaps:** Limited integration with tools like Slack, Gmail, or Logseq can cause work to be discussed or tracked outside GitHub, reducing visibility.
 
 ## Solution
+
 Adopt GitHub Projects as the OSPO’s centralized, shared workflow system and integrate it into all active projects and repositories. Use it as the default place to plan, track, and discuss OSPO work.
 
-+ **Centralized and transparent tracking:**
+- **Centralized and transparent tracking:**
 Use an organization-level project board to make all OSPO work visible, allowing team members to see, comment on, and follow progress without requiring work to be “perfect” or closed immediately.
 
-+ **Consistent team usage:**
+- **Consistent team usage:**
 Program coordinators and technical team members use the project regularly to plan, update, and coordinate work, establishing shared habits and accountability.
 
-+ **Onboarding and collaboration:**
-Label “good first issues” to support student onboarding and task tracking, as well as enable external collaborators to participate in discussions. 
+- **Onboarding and collaboration:**
+Label “good first issues” to support student onboarding and task tracking, as well as enable external collaborators to participate in discussions.
 
-+ **Simplified planning and reporting:**
+- **Simplified planning and reporting:**
 Project views, milestones, and iterations provide a straightforward way to track progress over time and generate reports without additional tools.
 
-### Key steps include:
+### Key steps include
 
 **Create a single organization-level GitHub Project:** Use one shared project board as the central place to track all OSPO activities across repositories and teams.
 
-**Standardize work intake using GitHub Issues:** Represent tasks as issues and link them to the project board, including required fields, such as assignees, ticket, and project details. 
+**Standardize work intake using GitHub Issues:** Represent tasks as issues and link them to the project board, including required fields, such as assignees, ticket, and project details.
 
-**Structure work with labels, milestones, and iterations:** Apply labels for work type and priority, use milestones for large deliverables, and iterations to plan work over time. 
+**Structure work with labels, milestones, and iterations:** Apply labels for work type and priority, use milestones for large deliverables, and iterations to plan work over time.
 
-**Streamline managment of multiple repositories:** Github enables issues from any repository to be managed within any project. 
+**Streamline managment of multiple repositories:** Github enables issues from any repository to be managed within any project.
 
 **Support onboarding and collaboration:** Use “good first issue” labels to onboard new contributors and enable both internal and external collaborators to participate openly.
 
 ## Resulting Context
-+ The OSPO gains a clear and collaborative picture of ongoing work across all teams and repositories. Staff can easily report progress and plan across projects. 
-+ Work is publicly visible, enabling simplified reporting not only for the OSPO but also for funders and PIs. Ongoing tasks can be aligned with grant requirements and grant work plans.
-+ Everyone on the team can see and comment on each other’s issues. This creates a sense of accountability and positive peer pressure, and it is extremely satisfying to complete each issue. 
-+ Keeping work open makes it possible for those external to the OSPO to follow along and contribute. 
+
+- The OSPO gains a clear and collaborative picture of ongoing work across all teams and repositories. Staff can easily report progress and plan across projects.
+- Work is publicly visible, enabling simplified reporting not only for the OSPO but also for funders and PIs. Ongoing tasks can be aligned with grant requirements and grant work plans.
+- Everyone on the team can see and comment on each other’s issues. This creates a sense of accountability and positive peer pressure, and it is extremely satisfying to complete each issue.
+- Keeping work open makes it possible for those external to the OSPO to follow along and contribute.
 
 **Potential Trade-offs:** Contributors unfamiliar with GitHub Projects may require additional training at the start.
 
 ### Additional Learning from The George Washington University
+
 We've already been contacted by someone (in another country) who is external to our OSPO and who wishes to contribute to our work. We plan to collaborate with them on another project.
 
 ## Known Instances
+
 [The GW Open Source Program Office, The George Washington University](https://ospo.gwu.edu/)
 
 ## References
+
 [GW OSPO Github Project Board](https://github.com/orgs/gw-ospo/projects/)
 
 ## Contributors & Acknowledgement
+
 - Jood Alfadhel, George Washington University, <https://orcid.org/0009-0000-2827-4036>
 - David Lippert, George Washington University, <https://orcid.org/0009-0003-6444-9595>
 - Sunil Shah, George Washington University, <https://orcid.org/0009-0009-4567-8679>

--- a/open-research-community-accelerator.md
+++ b/open-research-community-accelerator.md
@@ -18,21 +18,21 @@ Create a structured student pipeline for open source contributions, blending pai
 
 ## OSPO Problem / Challenge
 
-* Academic funding constraints combined with high turnover in universities hinder the development of high quality open source ecosystems.   
+* Academic funding constraints combined with high turnover in universities hinder the development of high quality open source ecosystems.
 * A lack of support and incentives for the maintenance of complex research software \- with a significant amount of research software being open in name only and often abandoned after initial release.  
 * Undergraduate students do not have a ‘real-world’ experience of software development and delivery at scale.
 
 ## Context
 
-In many universities, there may be a lack of formal research software support and educational programs to support open source software development. 
+In many universities, there may be a lack of formal research software support and educational programs to support open source software development.
 
 This leads to an ongoing skills gap in creating and maintaining open source projects (e.g. project management, remote collaborative work, outreach, community engagement) amongst students.
 
-The ‘pipeline’ of experienced contributors and maintainers for open source projects is regularly disrupted due to the transient nature of the student population. 
+The ‘pipeline’ of experienced contributors and maintainers for open source projects is regularly disrupted due to the transient nature of the student population.
 
 ## Forces
 
-Academic funding programs tend to favor new ideas and/or novel approaches over investing in or strengthening existing research or projects. 
+Academic funding programs tend to favor new ideas and/or novel approaches over investing in or strengthening existing research or projects.
 
 In general, funding programs have time constraints that remove support after a specific date. This creates barriers to sourcing long term funding of an open source project.
 
@@ -40,7 +40,7 @@ Faculty members are not incentivized to grow, and specifically maintain, complex
 
 ## Solution
 
-* Develop a student pipeline of new open source collaborators through a structured team-focused program and educational curriculum that teaches the specific skills needed for open source practices and also broader skills. 
+* Develop a student pipeline of new open source collaborators through a structured team-focused program and educational curriculum that teaches the specific skills needed for open source practices and also broader skills.
 
 * The program combines **paid internships, volunteering and for credit work** to collaborate on research translation projects and to develop open source solutions that create social impact and address community needs.
 
@@ -48,7 +48,7 @@ The solution below outlines basic core activities to consider:
 
 ### Outreach to potential partners
 
-* Conduct outreach to potential partners in the university, local businesses and community organizations to gauge interest in participating.     
+* Conduct outreach to potential partners in the university, local businesses and community organizations to gauge interest in participating.
 * A consultation exercise with potential partners may be necessary to determine ‘what works’ for partners; relevant open source research tools, and the type of training that will be most useful for the campus community.
 
 ### Design of program
@@ -56,9 +56,9 @@ The solution below outlines basic core activities to consider:
 * Design may be based on existing knowledge of similar internship programs and should also incorporate learning from consultation with partners.
 * Students (as opposed to faculty) define the tasks, design the work and negotiate with stakeholders.
 * The program may benefit from a student handbook covering expected codes of conduct and all university policies relevant to their internship.
-* If mentorship is a feature of the program, schedules should include space for teams to have regular mentoring sessions with their designated mentor (or mentors).   
+* If mentorship is a feature of the program, schedules should include space for teams to have regular mentoring sessions with their designated mentor (or mentors).
 * An accompanying program curriculum may also include classes, student assignments, coaching, team projects, self-directed tutorials in the form of open educational resources.
-* Design of curriculum should take into account the diverse range of projects and software that students may work on. The curriculum should also factor in other soft skills and broader skills that are vital to this work (e.g. project management, time management, design, intra-team communications, team work).     
+* Design of curriculum should take into account the diverse range of projects and software that students may work on. The curriculum should also factor in other soft skills and broader skills that are vital to this work (e.g. project management, time management, design, intra-team communications, team work).
 * Regular supervision time for student team leaders, and/or the teams themselves should also be built into the program schedule.
 
 ### Advertising to student population
@@ -74,7 +74,7 @@ Evaluation of students’ progress should account for the diversity of projects 
 Students may be graded in a number of ways including:
 
 * Customer feedback.  
-* Stakeholder feedback.   
+* Stakeholder feedback.
 * Mentor reviews.  
 * Learning journals.  
 * Self-evaluation.  
@@ -96,7 +96,7 @@ The program's mission - to make a meaningful impact by using open source to add 
 
 Our students have progressed from not knowing what open source is to creating a student club focused on open source. As of June 2024, three students have graduated with one progressing to work in our IT Department at UVM and another being hired by the organization they interned with (the Zoning Atlas project).
 
-Our hope is that this will impact open source practices at a faculty level as engagement from the graduate program increases. 
+Our hope is that this will impact open source practices at a faculty level as engagement from the graduate program increases.
 
 The program has also led to several speaking engagements about open source, research translation and innovation/entrepreneurship. This helps boost our engagement across a broader audience and build relationships with foundations interested in this kind of work.
 
@@ -108,7 +108,7 @@ The program has also led to several speaking engagements about open source, rese
 
 * [Open Research Community Accelerator (ORCA)](https://verso-uvm.github.io/ORCA/) - Website containing all information relevant to the ORCA program at the University of Vermont.
 * [Open Resource Library](https://www.openresourcelibrary.com) \- A student-driven resource for creating and maintaining open source.
-* [ORCA GitHub repository](https://github.com/VERSO-UVM/ORCA) \- Includes handbook, policies and other details   
+* [ORCA GitHub repository](https://github.com/VERSO-UVM/ORCA) \- Includes handbook, policies and other details
 * [ORCA Wiki](https://github.com/VERSO-UVM/ORCA/wiki) \- ORCA program at the University of Vermont - includes information about the program plus comprehensive information for interns.
 * [ORCA Onboarding Manual](https://github.com/VERSO-UVM/ORCA/wiki/Onboarding) \ Online onboarding training manual for interns.
 * [Open Science 101 Onboarding Materials](https://verso-uvm.github.io/Open-Science-101/README.html) \- ORCA program at the University of Vermont.
@@ -117,13 +117,12 @@ The program has also led to several speaking engagements about open source, rese
 
 [Open Source Capstone Course](https://github.com/CURIOSSorg/curioss-patterns/blob/main/open-source-capstone-course.md)
 [OSPO Student Ambassador Program](./ospo-student-ambassador-program.md)
-- [Open Source Capstone Course](./open-source-capstone-course.md)
-- [OSPO Student Ambassador Program](./ospo-student-ambassador-program.md)
+
+* [Open Source Capstone Course](./open-source-capstone-course.md)
+* [OSPO Student Ambassador Program](./ospo-student-ambassador-program.md)
 
 ## Contributor(s) & Acknowledgment
 
 * Clare Dillon (CURIOSS)  
 * Ciara Flanagan (CURIOSS) [https://orcid.org/0009-0005-3153-7673](https://orcid.org/0009-0005-3153-7673)  
 * Kendall Fortney (University of Vermont) [https://orcid.org/0009-0006-3898-0771](https://orcid.org/0009-0006-3898-0771)
-
-

--- a/open-source-ai-pilot.md
+++ b/open-source-ai-pilot.md
@@ -14,7 +14,7 @@ Develop a pilot program to investigate the capabilities and use of locally run �
 
 ## Problem / Challenge
 
-Large Language Models (LLMs) have grown extremely quickly in the past couple of years. Universities (both faculty and administration) are keen to make use of these new tools. 
+Large Language Models (LLMs) have grown extremely quickly in the past couple of years. Universities (both faculty and administration) are keen to make use of these new tools.
 
 However, there are a number of challenges:
 
@@ -43,11 +43,11 @@ A university or research institution with an interest in making use of AI.
 
 ## Solution
 
-Develop a pilot program to explore how to use AI tools in an open-source, academic environment. 
+Develop a pilot program to explore how to use AI tools in an open-source, academic environment.
 
-Define and communicate the criteria for the project. 
+Define and communicate the criteria for the project.
 
-Overall, the pilot should be: 
+Overall, the pilot should be:
 
 * Relatively low risk (to take account of LLM hallucinations).
 * Useful to faculty and the wider university community.
@@ -66,7 +66,7 @@ Using retrieval-augmentation generation (RAG) will improve LLM accuracy.
 
 ## Resulting Context
 
-Intended outcomes are: 
+Intended outcomes are:
 
 * Faculty and students can make use of open source AI tools that benefit their research activities.
   
@@ -76,11 +76,11 @@ Intended outcomes are:
 
 ### Additional Learning from Syracuse University
 
-We’ve hired two Masters of Science students to work on two pilot projects. 
+We’ve hired two Masters of Science students to work on two pilot projects.
 
 The first pilot is to build a chatbot that will answer questions about research being undertaken at our university. The objectives of the project are to improve access to university-based research; and to strengthen collaboration across campus.
 
-An unexpected finding was the lack of a central database of publications written by faculty - an essential requirement for the chatbot. We’re currently building that database (which is a project in itself). These papers are being used to improve the training of a locally run instance of LLAMA and should enable the chatbot (in theory) to give more accurate answers. 
+An unexpected finding was the lack of a central database of publications written by faculty - an essential requirement for the chatbot. We’re currently building that database (which is a project in itself). These papers are being used to improve the training of a locally run instance of LLAMA and should enable the chatbot (in theory) to give more accurate answers.
 
 Given the broader value of the database, we plan to make it publicly available when it’s completed.
 
@@ -88,7 +88,7 @@ The second project is a collaboration with an economics professor and her team t
 
 We hope to have a working solution by the end of the spring semester 2025.
 
-If the projects are successful, we will build similar tools that will be useful to the university community. 
+If the projects are successful, we will build similar tools that will be useful to the university community.
 
 In taking on this project, we also discovered that the GPU hardware on campus is becoming outdated. We are currently working with other faculty that are interested in AI to submit a funding proposal.
 
@@ -100,7 +100,7 @@ In taking on this project, we also discovered that the GPU hardware on campus is
 
 ## Contributors & Acknowledgement
 
-* Will Gearty, (Syracuse University), https://orcid.org/0000-0003-0076-3262
-* Ramya Patchala, (Syracuse University), https://orcid.org/0009-0009-3018-6030
-* Aryan Apte, (Syracuse University), https://orcid.org/0009-0001-9299-6217
-* Ciara Flanagan, https://orcid.org/0009-0005-3153-7673
+* Will Gearty, (Syracuse University), <https://orcid.org/0000-0003-0076-3262>
+* Ramya Patchala, (Syracuse University), <https://orcid.org/0009-0009-3018-6030>
+* Aryan Apte, (Syracuse University), <https://orcid.org/0009-0001-9299-6217>
+* Ciara Flanagan, <https://orcid.org/0009-0005-3153-7673>

--- a/open-source-capstone-course.md
+++ b/open-source-capstone-course.md
@@ -12,7 +12,7 @@ Redesign the traditional computer science capstone into a professional open sour
 
 ## Problem / Challenge
 
-- Undergraduate students do not have a 'real-world' experience of software development and delivery at scale. 
+- Undergraduate students do not have a 'real-world' experience of software development and delivery at scale.
 - Computer science students need to develop occupational skills and to demonstrate a level of experience as required by the tech sector.
 - Students completing traditional capstone courses may receive course credit but gain little authentic professional experience, limiting the value of the work to both students and external partners.
 - Promising capstone projects risk being abandoned after the course ends.
@@ -22,7 +22,7 @@ Redesign the traditional computer science capstone into a professional open sour
 - Education & Skills
 - Open Source Sustainability
 - Working with Tech Transfer / External Partners  
-   
+
 ## Context
 
 A university with a large and diverse research and instructional cohort.
@@ -39,13 +39,13 @@ Tech Leads, Mentors and Partners have an in-depth understanding of open source p
 
 Redesign a computer science capstone course that offers authentic professional development experience while producing open source software that creates real and lasting value.
 
-In this model, students are treated as professionals operating within a genuine open source ecosystem. Various types of mentorship are offered and students work with real clients. 
+In this model, students are treated as professionals operating within a genuine open source ecosystem. Various types of mentorship are offered and students work with real clients.
 
 The solution below outlines basic core activities to consider:
 
 ### Outreach to potential partners
 
-- Conduct outreach to potential partners across the university, industry and the open source ecosystem. 
+- Conduct outreach to potential partners across the university, industry and the open source ecosystem.
 - A consultation exercise with potential partners may be necessary to determine what kinds of projects are suitable and what level of engagement is realistic.
 - Establish clear expectations with partners about timelines, communication cadence, and the nature of the capstone development model.
 
@@ -61,9 +61,10 @@ Program design should be based on existing knowledge of similar capstone and int
 
 ### Create a structure of team management
 
-Engage and train graduate students as 'Tech Leads' to supervise projects and to support undergraduate development teams. 
+Engage and train graduate students as 'Tech Leads' to supervise projects and to support undergraduate development teams.
 
 The Tech Leads will serve as ‘near-peer’ mentors who can provide support at scale without overburdening faculty.
+
 - Advertise and recruit graduate students on relevant courses.
 - Run pre-semester preparatory workshops (e.g. [Building Open Leadership Toolsets](https://oss-slu.github.io/programs/bolt)) to ensure they are ready to begin on the first day of class with a deep understanding of their codebase and a clear product vision.
 
@@ -75,8 +76,8 @@ The Tech Leads will serve as ‘near-peer’ mentors who can provide support at 
 ### Advertising to student population
 
 - A transparent selection process for candidates should be put in place.
-- Target the relevant student cohort to advertise the program. 
-- Student referrals may also be a useful recruitment tool. 
+- Target the relevant student cohort to advertise the program.
+- Student referrals may also be a useful recruitment tool.
 
 ### Team recruitment
 
@@ -85,9 +86,9 @@ The Tech Leads will serve as ‘near-peer’ mentors who can provide support at 
 
 ### IP considerations
 
-IP considerations can be complex where students are both receiving course credit and being paid for their work. All projects should carry an open source license and licensing should be an explicit part of student evaluation. 
+IP considerations can be complex where students are both receiving course credit and being paid for their work. All projects should carry an open source license and licensing should be an explicit part of student evaluation.
 
-It is advisable to prepare a clear IP waiver and seek institutional approval in advance. 
+It is advisable to prepare a clear IP waiver and seek institutional approval in advance.
 
 Where commercialization pathways are of interest, more information should be made available to students.
 
@@ -95,24 +96,24 @@ Where commercialization pathways are of interest, more information should be mad
 
 The goal of the assessment process is not just to assign a grade but to provide students with strategic guidance for their career development.
 
-Evaluation should be holistic rather than points-based. The evaluation also needs to account for the diversity of projects and the different requirements in terms of onboarding, learning, and contributions. All assignments and deadlines serve as evidence for the holistic assessment rather than being calculated into a final grade. 
+Evaluation should be holistic rather than points-based. The evaluation also needs to account for the diversity of projects and the different requirements in terms of onboarding, learning, and contributions. All assignments and deadlines serve as evidence for the holistic assessment rather than being calculated into a final grade.
 
 The holistic assessment draws on several streams of evidence:
 
 - **Final outcomes and growth trajectory:** The primary focus is on what students have achieved over the full arc of the program and how they have developed, rather than on individual assignment scores.
 - **Assignments and checkpoint documents:** All assignments, deadlines and associated points serve as evidence-based grounding for understanding what happened at various points throughout the 16-plus weeks of work. They are indirect influences on the holistic assessment rather than direct inputs to a final grade calculation.
-- **Client and team feedback:** The team provides feedback on all members including the client. The client's voice carries additional weight in the overall assessment. 
+- **Client and team feedback:** The team provides feedback on all members including the client. The client's voice carries additional weight in the overall assessment.
 - **Collaboration and communication patterns:** Observational evidence of how students actually do the work (e.g. their engagement on Slack, their conduct in meetings, their responsiveness to peers and clients) is a vital part of the assessment.
 - **Weekly delivery:** How students deliver on a week-to-week basis (e.g. demo videos, merged pull requests, checkpoint documents) is an important indicator of their ability to stay on task and drive towards outcomes.
 - **A 10% stretch component:** This can be used to reward demonstrations of professional excellence and, for graduate students, public demonstrations of professional leadership such as conference presentations or contributions to major open source projects.
 
 ## Resulting Context
 
-Students gain legitimate professional experience - not merely course credit - and develop the occupational, collaborative and communication skills needed to engage with open source ecosystems throughout their careers. 
+Students gain legitimate professional experience - not merely course credit - and develop the occupational, collaborative and communication skills needed to engage with open source ecosystems throughout their careers.
 
 Real clients receive quality software that addresses their genuine needs.
 
-The OSPO builds a sustainable pipeline of contributors and maintainers for products that persist across student cohorts through structured handoff processes and long-lived product documentation. 
+The OSPO builds a sustainable pipeline of contributors and maintainers for products that persist across student cohorts through structured handoff processes and long-lived product documentation.
 
 ### Additional Learning from Open Source with SLU
 
@@ -127,8 +128,8 @@ Multi-semester product handoffs are achievable and highly valuable. As the progr
 The program has grown to over 23 active products across more than three years, with an estimated value of over $500,000 in development work delivered. The program currently enrolls 62 undergraduate and 24 graduate students in a single semester.
 
 ### Additional Learning from The GW Open Source Program Office
-We did a guest lecture in a data science capstone to teach students about project management. We have also worked with that professor to bring in projects from industry, government and other groups. Professor Amir Jafari has open sourced his [capstone program](https://github.com/amir-jafari/Capstone) which enables anyone to submit a project that students can opt to work on.
 
+We did a guest lecture in a data science capstone to teach students about project management. We have also worked with that professor to bring in projects from industry, government and other groups. Professor Amir Jafari has open sourced his [capstone program](https://github.com/amir-jafari/Capstone) which enables anyone to submit a project that students can opt to work on.
 
 ## Known Instances
 
@@ -143,6 +144,7 @@ Open Source with SLU, Saint Louis University
 - [Building Software Engineering Capacity through a University Open Source Program Office](https://dl.acm.org/doi/10.1145/3663529.3663866) Ekaterina Holdener; Daniel Shown
 
 ### Related Patterns
+
 - [Open Research Community Accelerator (ORCA)](https://github.com/CURIOSSorg/curioss-patterns/blob/main/open-research-community-accelerator.md)
 - [Summer Internship Program](https://github.com/CURIOSSorg/curioss-patterns/blob/main/summer-internship-program.md)
 - [Open Research Community Accelerator (ORCA)](./open-research-community-accelerator.md)
@@ -150,9 +152,9 @@ Open Source with SLU, Saint Louis University
 
 ## Contributors & Acknowledgement
 
-- Ciara Flanagan, https://orcid.org/0009-0005-3153-7673
-- Daniel Shown (Saint Louis University), https://orcid.org/0009-0002-5716-8835
-- David Lippert (The George Washington University), https://orcid.org/0009-0003-6444-9595
-- Richard Littauer, https://orcid.org/0000-0001-5428-7535
+- Ciara Flanagan, <https://orcid.org/0009-0005-3153-7673>
+- Daniel Shown (Saint Louis University), <https://orcid.org/0009-0002-5716-8835>
+- David Lippert (The George Washington University), <https://orcid.org/0009-0003-6444-9595>
+- Richard Littauer, <https://orcid.org/0000-0001-5428-7535>
 
 **A note on AI use:** In addition to working from Deep Dive transcripts, capturing learning from our community discussions and other patterns from our members, this pattern was drafted with the help of AI. As a small organization, tools like this help us turn rich conversations into written resources without losing the ideas along the way. As always, there were plenty of human eyes reviewing, editing and improving the content before this pattern made it to publication. Thanks go to our community for the insights. If you do spot any errors, please let us know so we can correct them!

--- a/open-source-catalog.md
+++ b/open-source-catalog.md
@@ -3,7 +3,7 @@ tags:
   - Community Building
   - Open Source Discovery
 ---
-# Open Source Catalog 
+# Open Source Catalog
 
 ## Pattern Theme / Category
 
@@ -13,16 +13,16 @@ tags:
 ## OSPO Problem / Challenge
 
 * A lack of up to date information on how much open source software is being produced in a university.  
-    
+
 * There is no effective mechanism to identify or to share information about open source creators, users, or projects within a university.  
-    
+
 * The lack of visibility makes it difficult to build community, foster collaboration, and contribute to the overall sustainability of open source efforts on campus.
 
 ## Context
 
-A large and decentralized university. 
+A large and decentralized university.
 
-There is no central policy or mandate governing the creation or use of open source software (OSS). There is no requirement to register open source work or seek approval prior to creating or transitioning software to be open source. 
+There is no central policy or mandate governing the creation or use of open source software (OSS). There is no requirement to register open source work or seek approval prior to creating or transitioning software to be open source.
 
 Open source software is being created by affiliates of all types (e.g. students, faculty, researchers, staff), in many different contexts, for example: in classes, in labs, for personal use and/or to fulfill grant requirements.
 
@@ -40,10 +40,10 @@ There is limited time and personnel to identify, track, and catalog OS projects
 
 Create a tool to collect and promote university OSS projects. The tool provides a public, centralized resource for creating awareness of university OSS projects.
 
-* As an initial step, create a draft catalog. Some useful tools for experimenting are [WordPress plugins](https://wordpress.org/plugins/), embedding XLS sheets, creating tables, etc.   
-    
+* As an initial step, create a draft catalog. Some useful tools for experimenting are [WordPress plugins](https://wordpress.org/plugins/), embedding XLS sheets, creating tables, etc.
+
 * Consideration should be given to data fields, free text for submission and control vocabularies for sorting and filtering. ([Microsoft Lists](https://www.microsoft.com/en-ie/microsoft-365/microsoft-lists) is helpful for establishing a set of entries.)  
-    
+
 * Holding informal consultations with colleagues for feedback on accessibility, style and structure can be very useful.
 
 * Publish the catalog on the institution’s OSPO website or on another relevant site.
@@ -52,13 +52,13 @@ Create a tool to collect and promote university OSS projects. The tool provides 
 
 ### Additional learning from the Johns Hopkins University OSPO
 
-In our case, we created a submission form using Gravity Forms and used [Gravity Kit](https://www.gravitykit.com/products/gravityview/?ref=853&gad_source=1) (formerly Gravity View) for the catalog. 
+In our case, we created a submission form using Gravity Forms and used [Gravity Kit](https://www.gravitykit.com/products/gravityview/?ref=853&gad_source=1) (formerly Gravity View) for the catalog.
 
 The JHU OSPO now has a central, easily accessible location for gathering and sharing information about OSS projects on campus. This has the potential to increase collaboration and knowledge sharing among open source creators.
 
 The catalog is only one of many initiatives aimed at discovering OSS projects on campus but it is essential in that it provides an easily accessible, centralized resource for capturing information about these projects and sharing this information broadly. Over time, we hope that more projects will contribute directly to the catalog. As it grows, the catalog will provide a better sense of open source activity and help us achieve our community-building goals.
 
-Next steps are to publicize, encourage use and incentivize entries. Badging and gamification are under consideration. 
+Next steps are to publicize, encourage use and incentivize entries. Badging and gamification are under consideration.
 
 ### Additional learning from OpenSource@Stanford
 
@@ -66,7 +66,7 @@ One of the objectives of the university-wide ‘[Open Source Software Prize](htt
 
 ## Known Instances
 
-* [JHU Open Source Programs Office](https://ospo.library.jhu.edu/), Sheridan Libraries, Johns Hopkins University   
+* [JHU Open Source Programs Office](https://ospo.library.jhu.edu/), Sheridan Libraries, Johns Hopkins University
 * [Georgia Tech Open Source Program Office](https://ospo.cc.gatech.edu/), Georgia Institute of Technology  
 * [OpenSource@Stanford](https://opensource.stanford.edu/), Stanford Data Science Center for Open and Reproducible Science (CORES), Leland Stanford Junior University
 * [GW OSPO Project Registry](https://ospo.gwu.edu/project-registry), George Washington University
@@ -80,6 +80,7 @@ One of the objectives of the university-wide ‘[Open Source Software Prize](htt
 * [Pattern: Open Source Software Prize](https://docs.google.com/document/d/1b5Bwuj8ZKbGSchBkpDgyK_3e1MAklxK7rYQ9Fdl-nfE/edit?usp=sharing)
 
 ### Related Patterns
+
 * [Maintainers & Contributors Roundtable](./maintainers-and-contributors-roundtable.md)
 * [OSPO Website](./ospo-website.md)
 

--- a/open-source-grant-commitment-letter.md
+++ b/open-source-grant-commitment-letter.md
@@ -31,7 +31,7 @@ An OSPO with the resources/capacity to supply grant commitment letters (that mee
 
 ## Forces
 
-Teams working on proposals face competing pressures and time constraints when submitting proposals and their primary concern is the proposal narrative and budget. 
+Teams working on proposals face competing pressures and time constraints when submitting proposals and their primary concern is the proposal narrative and budget.
 
 Other components of a grant application (e.g. open source, OSS) may be outside their area of expertise and/or their area of concern.
 
@@ -43,7 +43,7 @@ Provide a standard commitment letter to researchers to include in their grant ap
 
 Dear Review Panel
 
-If the proposal submitted by [NAME OF RESEARCHER/FACULTY MEMBER] entitled [NAME OF PROJECT] is selected for funding, it is my intent to collaborate and/or commit resources as detailed in the Project Description or the Facilities, Equipment, or Other Resources section of the proposal. 
+If the proposal submitted by [NAME OF RESEARCHER/FACULTY MEMBER] entitled [NAME OF PROJECT] is selected for funding, it is my intent to collaborate and/or commit resources as detailed in the Project Description or the Facilities, Equipment, or Other Resources section of the proposal.
 
 Sincerely
 
@@ -69,7 +69,7 @@ The initial outcome of this commitment letter is appreciation and education from
 * [The GW Open Source Program Office](https://ospo.gwu.edu/), The George Washington University
 * [Open Source with SLU](https://oss-slu.github.io/), Saint Louis University
 * [The UT Austin OSPO](https://opensource.utexas.edu/), The University of Texas at Austin
-* [UW-Madison Open Source Program Office](https://ospo.wisc.edu/), Data Science Institute, University of Wisconsin-Madison 
+* [UW-Madison Open Source Program Office](https://ospo.wisc.edu/), Data Science Institute, University of Wisconsin-Madison
 
 ## References
 
@@ -81,5 +81,5 @@ The initial outcome of this commitment letter is appreciation and education from
 
 ## Contributors & Acknowledgement
 
-* David Lippert (The George Washington University) https://orcid.org/0009-0003-6444-9595
-* Ciara Flanagan https://orcid.org/0009-0005-3153-7673
+* David Lippert (The George Washington University) <https://orcid.org/0009-0003-6444-9595>
+* Ciara Flanagan <https://orcid.org/0009-0005-3153-7673>

--- a/open-source-software-prize.md
+++ b/open-source-software-prize.md
@@ -8,14 +8,6 @@ tags:
 ---
 # Open Source Software Prize
 
-### Pattern Theme / Category
-
-* Community Building
-* DEI
-* Promoting good practices
-* OSS Discovery  
-* Reward & Recognition  
-
 ## OSPO Problems / Challenges
 
 * A lack of up to date information on how much open source software is being produced in a university.  
@@ -46,21 +38,21 @@ Develop a university-wide ‘Open Source Software Prize’ with the objectives o
 
 * Identifying labs and research teams working in open source that are outside of known networks.  
 * Tying prize eligibility to being listed in the Registry (to incentivize participation and discovery).  
-* Raising awareness of and elevating best practices in open source and open science.   
+* Raising awareness of and elevating best practices in open source and open science.
 * Rewarding best practices and those projects making an impact in relation to diversity and inclusion.  
 * Contributing to the [ORCID](https://orcid.org/) ecosystem to recognize researchers and build trust.
 
-The prize can be used as a vehicle for encouraging the adoption of open science tools to underrepresented fields. 
+The prize can be used as a vehicle for encouraging the adoption of open science tools to underrepresented fields.
 
 ORCID records are permanent and belong to  the researcher. Leveraging ORCID for official prize assertions makes the distinction more visible, durable, and relevant to the research community.
 
 A sample list of typical awards for entrants may include:
 
 * Cash prizes.  
-* Public recognition in academic fora.   
+* Public recognition in academic fora.
 * Official distinctions that incorporate a ‘permanent academic recognition’ of achievement.
 
-Award criteria should be devised to reward projects demonstrating practices and impact that the university wishes to foster in open source projects. 
+Award criteria should be devised to reward projects demonstrating practices and impact that the university wishes to foster in open source projects.
 
 Awards criteria should account for biases and limitations in scholarly metrics. For example, some impactful software projects in computer science may not have associated articles or preprints. In the absence of DOIs, other measures of industry impact are needed.
 
@@ -73,17 +65,19 @@ A sample evaluation rubric may include:
 
 Additional evaluation rubrics used by the GW OSPO for their student awards
 
-**Open Source Project Awards**
+### Open Source Project Awards
 
 Criteria - judging based on 4 categories evaluated with equal weight
+
 * 25% - Reproducibility - care taken to ensure the project is easily and accurately reproducible
 * 25% - Impact - Meaningful and interesting project
 * 25% - Adherence to open-source and software development best practices
 * 25% - Collaboration - inclusivity, cross discipline, demonstrative community building
 
-**Individual Contributor Awards**
+### Individual Contributor Awards
 
 Complete applications will be evaluated and must meet a minimum threshold to be entered in the lottery:
+
 * Must include at least one meaningful contribution of code or documentation addressing existing issues and accepted by the maintainer of an existing active Project
 * The project you contribute to may be a GW or external project, but our evaluation committee will verify that the contributions are beneficial and not trivial
 
@@ -105,9 +99,9 @@ The open source best practices criterion of the scoring rubric can be used as a 
 ## References
 
 * [https://opensource.stanford.edu/prize](https://opensource.stanford.edu/prize)  
-* [https://datascience.stanford.edu/cores/cores-annual-symposium-2024](https://datascience.stanford.edu/cores/cores-annual-symposium-2024)   
+* [https://datascience.stanford.edu/cores/cores-annual-symposium-2024](https://datascience.stanford.edu/cores/cores-annual-symposium-2024)
 * [https://opensource.stanford.edu/projects-registry](https://opensource.stanford.edu/projects-registry)  
-* [Pattern: Open Source Project Catalog](https://docs.google.com/document/d/1FSkp38gLwZoKAc2oLBMD56EJsijCsNKdCNaoaadRtTc/edit?usp=sharing) 
+* [Pattern: Open Source Project Catalog](https://docs.google.com/document/d/1FSkp38gLwZoKAc2oLBMD56EJsijCsNKdCNaoaadRtTc/edit?usp=sharing)
 
 ## Contributor(s) & Acknowledgment
 

--- a/open-source-survey.md
+++ b/open-source-survey.md
@@ -66,6 +66,7 @@ We also recruited an outreach specialist to contact people identified through in
 ### Additional Learning from University of California Santa Barbara
 
 We conducted a survey across the UC system and ultimately received about 300 responses. Since we wanted to present the results in a scholarly format, we began by working with the Office of Research and the Institutional Review Board. Once we had IRB approval, we left the survey open for one month and advertised it as widely as possible. We maintain a "lessons learned" document with learnings particular to our survey instrument. (See [References](#references) section below.) Virginia gave a lightning talk at the February 2026 CURIOSS Gathering in Dublin describing some of our lessons learned (you can find it on the CURIOSS YouTube channel), but here are the highlights (plus some additional thoughts):
+
 * Have a distribution plan. We received some (justified) criticism from reviewers that our sample size was too small. The truth is that we fought hard to get those 300 responses. On many campuses, our requests to forward the survey were routinely denied, and our paper flyers were removed. (If you use paper flyers, check campus regulations on allowed posting locations.) Try to get to know the listserv administrators, or anyone who can post to a listserv, before the survey period starts. Go to student group fairs and introduce yourself to the students at the booths. Go to events hosted by student groups and introduce yourself to the hosts. Go to research seminars and introduce yourself to the researchers. These relationships can be your way in to their listservs. Also, we had better success getting through to the listservs via undergraduate advisers as opposed to pure admin front office staff or subject librarians. Your department's communication staff may have other ideas. Individualized communications have better success. Budget a LOT of time for this.
 * Use both qualitative and quantitative questions. Each has their strengths and drawbacks.
 * We found three overarching themes in our data: culture, resources, and infrastructure. We believe these three themes could serve as a blueprint for creating a comprehensive survey. Make sure you ask questions about all three.
@@ -88,7 +89,7 @@ We conducted a survey across the UC system and ultimately received about 300 res
 * [GW Open Source Survey](https://ospo.gwu.edu/gw-open-source-survey) \- Information about the George Washington University’s Open Source Survey.
 * [UC 2025 Survey Website](https://ucospo.net/oss-resources/survey/) \- All research artifacts from the University of California 2025 survey.
 
-### Related Patterns 
+### Related Patterns
 
 * [OSPO Mailing List](./ospo-mailing-list.md)
 * [Publish an OSPO Newsletter](./publish-an-ospo-newsletter.md)

--- a/organize-an-open-source-hackathon.md
+++ b/organize-an-open-source-hackathon.md
@@ -15,14 +15,16 @@ tags:
 Organize an open source hackathon to promote open source on campus.
 
 ## Problem / Challenge
+
 - Students report a lack of ‘hands-on’ opportunities to collaborate on or contribute to ‘real world’ open source projects.
 - Undergraduate students also lack experience of ‘real world’ software development and delivery at scale.
 - There is a gap in awareness and/or motivation amongst students on best practices in open source and open science.
-- Students with an interest in open source are unlikely to be connected with peers who are based in different departments within their university. 
-- Students may also be disconnected from broader open source movements like Hacktoberfest. 
+- Students with an interest in open source are unlikely to be connected with peers who are based in different departments within their university.
+- Students may also be disconnected from broader open source movements like Hacktoberfest.
 - Faculty researchers need help extending their work but may lack resources.
 
 ## Pattern Category
+
 - Awareness
 - Community Building
 - Education & Skills
@@ -30,146 +32,163 @@ Organize an open source hackathon to promote open source on campus.
 - Rewards & Recognition
 - Supporting OSS development
 - Working with Tech Transfer / External Partners  
-   
+
 ## Context
-A university or research institution. 
+
+A university or research institution.
 An OSPO has been established.
 
 ## Forces
+
 - Funding has become available for a hackathon either through external sponsorship or a successful grant application.
 - A hackathon may be scheduled to connect to wider activities (e.g. Hacktoberfest, Earth Day).
 - OSPO staff have the time and resources to organize a hackathon.
 - Physical space is available for participants to work during the hackathon.
-- Universities have computing infrastructure, faculty expertise and research centers that would benefit from more student engagement. 
+- Universities have computing infrastructure, faculty expertise and research centers that would benefit from more student engagement.
 - Potential participants have varying levels of prior experience and different goals (e.g. learning, networking, competition, portfolio building).
 
 ## Solution
+
 Organize an open source hackathon that facilitates collaboration on open source projects; promotes open source skills development; and fosters the open source community on campus.
 
 ### Designing the Hackathon
+
 The list below covers broad areas for consideration when designing/programming a hackathon:
 
-* The theme should take the following into account: the wider university’s priorities; specific requests from an external sponsor and existing research and open source projects on campus that would benefit from a hackathon’s input. 
-* The hackathon model, i.e. competitive vs collaborative. This will inform the nature of participation and collaboration throughout the event. 
-* The hackathon model will also influence decisions relating to prizes and recognition for participants e.g. cash prizes vs universal participation prizes (gift cards). Prize categories may focus on skills development rather than outputs (e.g. best use of open source, best research advancement).
-* The audience and stakeholders including participants, mentors and judges.
-* Participation from minors - any participation from minors will require liaising with risk or event management teams and further decisions on waivers; transport to and from the venue; and an appropriate finish time for this cohort each day.
-* The threshold for participation i.e. do participants need to be physically present at all times? 
+- The theme should take the following into account: the wider university’s priorities; specific requests from an external sponsor and existing research and open source projects on campus that would benefit from a hackathon’s input.
+- The hackathon model, i.e. competitive vs collaborative. This will inform the nature of participation and collaboration throughout the event.
+- The hackathon model will also influence decisions relating to prizes and recognition for participants e.g. cash prizes vs universal participation prizes (gift cards). Prize categories may focus on skills development rather than outputs (e.g. best use of open source, best research advancement).
+- The audience and stakeholders including participants, mentors and judges.
+- Participation from minors - any participation from minors will require liaising with risk or event management teams and further decisions on waivers; transport to and from the venue; and an appropriate finish time for this cohort each day.
+- The threshold for participation i.e. do participants need to be physically present at all times?
 
 ### Finances
+
 During the planning stage, the following financial process/budget lines should be considered:
 
-* The overall budget.
-* A food budget for participants.
-* Providing clear instructions for funding and payment processes.
+- The overall budget.
+- A food budget for participants.
+- Providing clear instructions for funding and payment processes.
 
 ### Identify internal partners
-Typical partners include members of: 
 
-* IT team
-* Research centers
-* Computing departments
-* Communications/marketing team
-* Student support services
-* Student organizations
+Typical partners include members of:
+
+- IT team
+- Research centers
+- Computing departments
+- Communications/marketing team
+- Student support services
+- Student organizations
 
 For research hackathons, recruit faculty to propose research projects and provide mentorship.
 
 Student organizations are also valuable in terms of hackathon promotion and recruitment of participants.
 
 ### Critical first steps
-* Set up an organizing team comprising both colleagues and students (where possible). 
-* Secure an appropriate venue that includes both a large space for opening, closing, awards and teamwork and smaller spaces for workshops, small group work, solo working and rest breaks. 
-* Select a date that takes account of the academic, sports and events calendar. Consideration should be given to potential participants who will not be able to miss class during weekdays. 
-* As soon as the date is confirmed, share a ‘save the date’.
+
+- Set up an organizing team comprising both colleagues and students (where possible).
+- Secure an appropriate venue that includes both a large space for opening, closing, awards and teamwork and smaller spaces for workshops, small group work, solo working and rest breaks.
+- Select a date that takes account of the academic, sports and events calendar. Consideration should be given to potential participants who will not be able to miss class during weekdays.
+- As soon as the date is confirmed, share a ‘save the date’.
 
 ### Promoting the Hackathon
-* Prioritize engagement with the institution’s communications/marketing team to agree on key communication points and messaging.
-* Promote the hackathon on the OSPO website and university website (if possible). 
-* Leverage student communication channels to promote the event. 
-* Share flyers in and around campus.
-* Request faculty to make announcements or make announcements at lectures.
+
+- Prioritize engagement with the institution’s communications/marketing team to agree on key communication points and messaging.
+- Promote the hackathon on the OSPO website and university website (if possible).
+- Leverage student communication channels to promote the event.
+- Share flyers in and around campus.
+- Request faculty to make announcements or make announcements at lectures.
 
 All communications should include a link to the hackathon registration form.
 
-### Other important tasks:
+### Other important tasks
+
 The following includes but is not limited to:
 
-* Emailing people with the registration form and sending reminders about the event to participants.
-* Recruiting mentors and judges.
-* Recruiting volunteers for support during the event. Support roles may include guides and facilitators.
-* Preparing explainers that outline the expectations of each role. Copies of the explainers should be on hand during the event.
-* Defining the judging criteria (if applicable).
-* Hosting orientation/induction workshops before or during the hackathon to familiarize both participants, volunteers and mentors.
-* Devising problem statements.
-* Ensuring that catering includes snacks and drinks that are available in between meals.
-* Developing and sharing pre and post surveys to evaluate the impact for all involved.
+- Emailing people with the registration form and sending reminders about the event to participants.
+- Recruiting mentors and judges.
+- Recruiting volunteers for support during the event. Support roles may include guides and facilitators.
+- Preparing explainers that outline the expectations of each role. Copies of the explainers should be on hand during the event.
+- Defining the judging criteria (if applicable).
+- Hosting orientation/induction workshops before or during the hackathon to familiarize both participants, volunteers and mentors.
+- Devising problem statements.
+- Ensuring that catering includes snacks and drinks that are available in between meals.
+- Developing and sharing pre and post surveys to evaluate the impact for all involved.
 
 ### Equipment and resources
+
 The following items are essential items for any hackathon:
 
-* Power strips
-* Name badges
-* Pens
-* Whiteboards or flipcharts
-* External screens/monitors are useful but may not be essential.
-* Cloud storage platforms (e.g. [Jetstream 2](https://jetstream-cloud.org/index.html)) may be necessary for supercomputing requirements.
+- Power strips
+- Name badges
+- Pens
+- Whiteboards or flipcharts
+- External screens/monitors are useful but may not be essential.
+- Cloud storage platforms (e.g. [Jetstream 2](https://jetstream-cloud.org/index.html)) may be necessary for supercomputing requirements.
 
 ### Post hackathon tasks
+
 - Send ‘Thank You’ communications to participants, mentors, judges and volunteers.
 - Report outcomes publicly on the OSPO website, newsletter, campus press and social media channels. Links to all deliverables and outputs should be shared in communications e.g. finalist projects, GitHub repos.
 - Review survey data for learning.
 - Document lessons learned to improve future events
 
 ## Resulting Context
+
 Participants learn about open source best practices; gain practical technical experience; and produce portfolio-worthy projects.
 
 Participants develop networking connections and the wider open source community on campus is strengthened.
 
 Faculty research advances through collaborative problem-solving.
 
-Open source contributions may extend beyond the event if sustainability is planned. 
+Open source contributions may extend beyond the event if sustainability is planned.
 
 Hackathons also have the potential to position the university as a leader in open source or as an innovation hub in relation to the event’s chosen theme.
 
 ### Other learning
-* Actual attendance tends to be lower than registration numbers and this should be considered as part of the planning process.
-* Hackathon organizers manage intensive communication demands and coordination before and during the event. Scheduling a rest break when the hackathon ends is essential.
-* Success creates expectations for future events, requiring ongoing resource commitments
-* Projects may remain short-term without intentional sustainability planning.
+
+- Actual attendance tends to be lower than registration numbers and this should be considered as part of the planning process.
+- Hackathon organizers manage intensive communication demands and coordination before and during the event. Scheduling a rest break when the hackathon ends is essential.
+- Success creates expectations for future events, requiring ongoing resource commitments
+- Projects may remain short-term without intentional sustainability planning.
   
 ### Additional Learning from Carnegie Mellon University OSPO
-A significant amount of project management and time is required for hackathons. It’s important that the OSPO lead ensures that everyone involved understands their role, tasks and the event schedule. 
 
-Most students work on their own laptops. However, it may be necessary to provide some monitors. 
+A significant amount of project management and time is required for hackathons. It’s important that the OSPO lead ensures that everyone involved understands their role, tasks and the event schedule.
 
-Access to a supercomputer will depend on the theme and scale of the hackathon. 
+Most students work on their own laptops. However, it may be necessary to provide some monitors.
+
+Access to a supercomputer will depend on the theme and scale of the hackathon.
 
 ### Additional Learning from the University of California, Santa Cruz
-It’s important not to underestimate the amount of time that project management and communications take up when organizing a hackathon - especially a hackathon where you have different people participating in different ways. 
+
+It’s important not to underestimate the amount of time that project management and communications take up when organizing a hackathon - especially a hackathon where you have different people participating in different ways.
 
 We recommend having more than one person to share responsibility for project management and to ensure seamless communication loops.
 
 ### Additional Learning from the University of Texas OSPO
-Each hackathon has its own organizing team. It’s essential that students are on the organizing team for promotion (through informal student channels) and participant recruitment. 
+
+Each hackathon has its own organizing team. It’s essential that students are on the organizing team for promotion (through informal student channels) and participant recruitment.
 
 A useful piece of participant feedback was for the organizers to make more use of social media channels. This particularly relates to announcing winners on LinkedIn where potential employers can learn more about students’ achievements.
 
-We’ve also learned, as organizers, that it’s really important to host internal communications on a group communication platform (e.g. [Discord](https://discord.com/)). 
+We’ve also learned, as organizers, that it’s really important to host internal communications on a group communication platform (e.g. [Discord](https://discord.com/)).
 
-Our hackathon teams have access to the supercomputing center in Indiana and we pre-set our event with that. 
+Our hackathon teams have access to the supercomputing center in Indiana and we pre-set our event with that.
 
-Students bring their own laptops and their own power supply. We have extra power supply and power strips on hand for students. 
+Students bring their own laptops and their own power supply. We have extra power supply and power strips on hand for students.
 
 We also provide each team with a dedicated space to work.
 
-We host ‘pop-in’ presentations three times a day to keep people on track and make sure everybody's okay. 
+We host ‘pop-in’ presentations three times a day to keep people on track and make sure everybody's okay.
 
 Every team has a mentor and we provide mentor training beforehand.
 
-We also deliver pre-training workshops for participants who are less familiar with open source on GitHub, Jupyter Notebooks, Python. 
+We also deliver pre-training workshops for participants who are less familiar with open source on GitHub, Jupyter Notebooks, Python.
 
 ## Known Instances
+
 - [CMU Open Source Program Office](https://www.library.cmu.edu/services/ospo), CMU Libraries, Carnegie Mellon University
 - [GW OSPO](https://ospo.gwu.edu/), George Washington University
 - [University of California OSPO Network](https://ucospo.net/)
@@ -177,14 +196,16 @@ We also deliver pre-training workshops for participants who are less familiar wi
 - [The University of Texas OSPO (UT-OSPO)](https://opensource.utexas.edu/), University of Texas at Austin
 
 ## References
-* [UCSC GraceHacks 2023 repository](https://github.com/emmet0r/gracehacks)
-* [UCSC Hacktoberfest 2024 event page](https://ucsc-ospo.github.io/event/20241010/)
-* [UCSC Hacktoberfest 2024 repository](https://github.com/emmet0r/hacktoberfest-2024)
-* [UCSC’s 2024 Ideathon (included OSPO-sponsored prize track)](https://lu.ma/d8afz220)
-* [OpenHatch: Open Source Comes to Campus](https://github.com/openhatch/open-source-comes-to-campus)
-* [GWU George Hacks - 2025 Innovation Hackathon](https://georgehacks.org)
+
+- [UCSC GraceHacks 2023 repository](https://github.com/emmet0r/gracehacks)
+- [UCSC Hacktoberfest 2024 event page](https://ucsc-ospo.github.io/event/20241010/)
+- [UCSC Hacktoberfest 2024 repository](https://github.com/emmet0r/hacktoberfest-2024)
+- [UCSC’s 2024 Ideathon (included OSPO-sponsored prize track)](https://lu.ma/d8afz220)
+- [OpenHatch: Open Source Comes to Campus](https://github.com/openhatch/open-source-comes-to-campus)
+- [GWU George Hacks - 2025 Innovation Hackathon](https://georgehacks.org)
 
 ### Related Patterns
+
 - [Design a Collaborative Open Source Hackathon](design-a-collaborative-open-source-hackathon.md)
 - [Embed wellbeing into Student Hackathons](embed-wellbeing-into-student-hackathons.md)
 - [Enable Student-led Hackathons](enable-student-led-hackathons.md)
@@ -193,9 +214,10 @@ We also deliver pre-training workshops for participants who are less familiar wi
 - [Lower the barriers to entry for Student Hackathons](lower-the-barriers-to-entry-for-student-hackathons.md)
 
 ## Contributors & Acknowledgement
+
 - Angela Newell, University of Texas at Austin
-- Ciara Flanagan, https://orcid.org/0009-0005-3153-7673
-- David Lippert, George Washington University, https://orcid.org/0009-0003-6444-9595
-- Emily Lovell, University of California Santa Cruz, https://orcid.org/0000-0001-5531-5956
+- Ciara Flanagan, <https://orcid.org/0009-0005-3153-7673>
+- David Lippert, George Washington University, <https://orcid.org/0009-0003-6444-9595>
+- Emily Lovell, University of California Santa Cruz, <https://orcid.org/0000-0001-5531-5956>
 - Laura Langdon, University of California, Davis
-- Tom Hughes, Carnegie Mellon University, https://orcid.org/0009-0008-7516-3687
+- Tom Hughes, Carnegie Mellon University, <https://orcid.org/0009-0008-7516-3687>

--- a/organize-one-off-workshops.md
+++ b/organize-one-off-workshops.md
@@ -47,17 +47,18 @@ Develop and deliver one-off workshops that address very specific knowledge gaps 
 ### Identify specific knowledge gaps that can be addressed by short workshops
 
 A training needs assessment can be carried out in a number of ways:
-* Individual consultations with students, researchers and faculty. 
+
+* Individual consultations with students, researchers and faculty.
 * A survey on training and/or open source needs.
 * Consultation with the OSPO’s advisory committee/user group.
 
-### Planning 
+### Planning
 
 Planning should take the following into account:
 
 * The cohort that will be targeted.
 * Learning goals.
-* What can realistically be covered in the selected timeframe (e.g. one hour, morning or afternoon workshop). 
+* What can realistically be covered in the selected timeframe (e.g. one hour, morning or afternoon workshop).
 * The most appropriate format e.g. virtual or in-person.
 * How best to promote the workshop.
 
@@ -66,7 +67,7 @@ Planning should take the following into account:
 Training workshops can be promoted via the following channels:
 
 * The OSPO website and social channels.
-* The OSPO mailing list. 
+* The OSPO mailing list.
 * Through key partners’ channels (e.g. the Office of Research, the Office of Computer Science, the Library).
 * Through student groups and students’ informal networks.
 
@@ -88,9 +89,9 @@ We always try to provide lunch at our in-person workshops.
 
 ### Additional Learning from University of Wisconsin-Madison
 
-Our curricula is a collaboration with [Software Carpentries](https://software-carpentry.org/) on OSS. 
+Our curricula is a collaboration with [Software Carpentries](https://software-carpentry.org/) on OSS.
 
-### Additional Learning from Syracuse University 
+### Additional Learning from Syracuse University
 
 We run workshops on computing 101 and intros to Python/R. They usually entail 4-6 x 2 hour segments in the style/format of Carpentries Workshops.
 
@@ -120,6 +121,5 @@ Another successful workshop was held at the George Hacks Innovation Hackathon.  
 
 * Dr. Angela Newell (University of Texas at Austin)
 * Dr. Alex Marden (University of Texas at Austin)
-* David Lippert (The George Washington University), https://orcid.org/0009-0003-6444-9595
-* Ciara Flanagan, https://orcid.org/0009-0005-3153-7673
-
+* David Lippert (The George Washington University), <https://orcid.org/0009-0003-6444-9595>
+* Ciara Flanagan, <https://orcid.org/0009-0005-3153-7673>

--- a/ospo-advisory-board.md
+++ b/ospo-advisory-board.md
@@ -46,7 +46,7 @@ Set up an Advisory Committee/Group to:
 
 - Better understand stakeholder needs.
 - Inform the OSPO’s strategic direction and activities.
-- Strengthen the OSPO’s profile and reach. 
+- Strengthen the OSPO’s profile and reach.
 - Develop strategic partnerships both within and outside of the institution
 - Maintain awareness of the evolving internal and external landscape in which the OSPO operates.
 - Promote the OSPO, its services and the importance of open source and open source software within academia.
@@ -60,28 +60,34 @@ The solution below outlines some core activities to consider. The sequence of th
 - Clarify the group's decision-making authority (purely advisory vs. some decision power).
 
 ### Identify optimal composition and size of the committee
+
 - Map out the key internal and external stakeholder groups that should be represented.
 - Determine ideal size of committee membership.
 - Balance institutional knowledge with external perspectives.
 
 ### Develop formal governance structure
+
 - Draft a charter outlining purpose, responsibilities, and procedures.
 - Establish meeting frequency and format.
 - Define communication channels between the Advisory Group and service leadership (if applicable).
 
 ### Recruit and onboard members
+
 - Agree on a recruitment strategy with senior leadership or management.
 - Approach potential members with clear expectations about commitment.
 
 ### Plan and facilitate effective meetings
+
 - Develop structured agendas with clear objectives.
 - Share relevant materials in advance.
 - Ensure balanced participation and productive discussion.
 
 ### Acknowledge and recognize contributions from the Advisory Group
+
 - Provide appropriate recognition for committee members' service at key events or in OSPO communications.
 
 ### Evaluate and evolve the advisory structure
+
 - Periodically review the group's composition and effectiveness.
 - Refresh membership as needed to maintain relevance and energy.
 
@@ -96,15 +102,18 @@ An academic OSPO can benefit from an Advisory Group in some or all of the follow
 - The OSPO can facilitate valuable connections and relationships between the university and external partners from both the region and the broader open source community.
 
 ### Additional learning from the George Washington University OSPO
+
 We have an OSPO stakeholder group. We don't use the term 'advisory' because we don't want our stakeholders to feel the need to advise us, rather, we are a community sharing ideas, feedback and working together.
 
 ### Additional learning from Saint Louis University
+
 We have a Faculty Advisory Board of experienced researchers and educators across the university. They provide strategic guidance on academic initiatives and ensure our program aligns with university priorities. Our Industry Advisory Board comprises seasoned technology leaders, open source practitioners, and innovation executives. Members provide insights into current market trends and workforce development needs.
 
 ### Additional learning from University of Wisconsin-Madison
-The UW-Madison OSPO identified the need for two distinct bodies to guide operations and provide strategic support during the planning phase. 
 
-The Executive Committee, composed of representatives from the Libraries, the Data Science Hub, and Madison College, was tasked with hiring the OSPO Manager and maintaining close collaboration with our office. These organizations were identified as crucial future partners in the original funding proposal. 
+The UW-Madison OSPO identified the need for two distinct bodies to guide operations and provide strategic support during the planning phase.
+
+The Executive Committee, composed of representatives from the Libraries, the Data Science Hub, and Madison College, was tasked with hiring the OSPO Manager and maintaining close collaboration with our office. These organizations were identified as crucial future partners in the original funding proposal.
 
 The OSPO Advisory Board drew from a broader range of campus and community stakeholders to guide the OSPO's overarching strategy.
 
@@ -120,14 +129,15 @@ Thus far our Stakeholder Group has been an enormous success.  The members are cr
 
 ## Known Instances
 
-* [UW-Madison Open Source Program Office](https://ospo.wisc.edu/), Data Science Institute, University of Wisconsin-Madison
-* [GW Open Source Program Office](https://ospo.gwu.edu/), The George Washington University
+- [UW-Madison Open Source Program Office](https://ospo.wisc.edu/), Data Science Institute, University of Wisconsin-Madison
+- [GW Open Source Program Office](https://ospo.gwu.edu/), The George Washington University
 
 ## References
-* Scroll down on the [Open Source with SLU Leadership page](https://oss-slu.github.io/people/leadership) for more information about the Faculty and Industry Advisory Boards.
+
+- Scroll down on the [Open Source with SLU Leadership page](https://oss-slu.github.io/people/leadership) for more information about the Faculty and Industry Advisory Boards.
 
 ## Contributors & Acknowledgement
 
-- Allison Kittinger https://orcid.org/0000-0002-3104-5995
-- Ciara Flanagan https://orcid.org/0009-0005-3153-7673
+- Allison Kittinger <https://orcid.org/0000-0002-3104-5995>
+- Ciara Flanagan <https://orcid.org/0009-0005-3153-7673>
 - David Lippert [https://orcid.org/0009-0003-6444-9595](https://orcid.org/0009-0003-6444-9595)

--- a/ospo-as-co-principal-investigator.md
+++ b/ospo-as-co-principal-investigator.md
@@ -10,9 +10,11 @@ tags:
 # OSPO as Co-Principal Investigator
 
 ## Pattern Summary
+
 Leverage OSPO staff’s open source expertise and cross-disciplinary collaboration skills to become co-Principal Investigators (co-PIs) on funding proposals.
 
 ## Problem / Challenge
+
 There has been a growth in recognition of the value of open source software amongst funders. Increasingly, funders require software to be released as open source and to make research outputs publicly available.
 
 OSPO staff may find themselves in supporting roles on funding proposals - providing open source expertise but lacking formal authority. This limits their ability to:
@@ -28,16 +30,17 @@ Meanwhile, research teams may lack the expertise needed to plan, execute, and su
 * Inefficient reinvention of existing tools.
 * Missed opportunities for collaboration and broader research impact.
 
-
 ## Pattern Category
-- Advocacy, Governance & Policy
-- Demonstrating value as an Academic OSPO
-- Funding & Financial Support
-- Open Source Development
-- Open Source Sustainability
-- Promoting Best Practices
-   
+
+* Advocacy, Governance & Policy
+* Demonstrating value as an Academic OSPO
+* Funding & Financial Support
+* Open Source Development
+* Open Source Sustainability
+* Promoting Best Practices
+
 ## Context
+
 A university or research institution that submits grant proposals to federal, state or private funding sources.
 
 PIs, other leaders and central institution or departmental grants offices are involved in the preparation of grant applications.
@@ -49,6 +52,7 @@ Research projects require software development and/or community engagement compo
 An OSPO with the resources/capacity for staff to take on co-PI leadership responsibilities.
 
 ## Forces
+
 Limited understanding amongst researchers of an OSPO professional's expertise or track record as a co-PI.
 
 Potential resistance from established researchers to sharing leadership authority.
@@ -58,11 +62,13 @@ Growing funder emphasis on open science practices and reproducibility.
 The OSPO and/or specific OSPO staff have a track record of successful open source project management.
 
 ## Solution
+
 Promote the OSPO as a co-PI for relevant/strategic funding proposals to ensure that open source impact is maximized and communicated.
 
 The solution below outlines questions or steps for the OSPO to consider:
 
 ### Strategic Positioning
+
 * Are there research areas where open source infrastructure is critical to success?
 
 * Does the OSPO have good relationships with a small number of research groups that can lead to valuable co-PI relationships?
@@ -74,7 +80,8 @@ The solution below outlines questions or steps for the OSPO to consider:
 * Has the OSPO developed a funding track record through support of or collaboration in smaller grants or industry partnerships?
 
 ### Co-PI Preparation
-* Does the OSPO have demonstration projects that showcase its ability to lead technical work packages? 
+
+* Does the OSPO have demonstration projects that showcase its ability to lead technical work packages?
 
 * Develop clear value propositions for the co-PI role that is focused on the OSPO’s unique expertise (e.g. knowledge of best practices, sustainability, community building, dissemination).
 
@@ -87,11 +94,13 @@ The solution below outlines questions or steps for the OSPO to consider:
   \- Plan for post-grant sustainability.
 
 ### Co-PI Execution
+
 * Allocate tasks for proposal submissions.
 
 * Following award of grants, set up meetings and processes based on the terms of the collaboration agreement.
 
 ## Resulting Context
+
 Research projects benefit from expert guidance on open source best practices.
 
 Research outputs have a better chance of creating greater impact through community building and planning for long-term sustainability.
@@ -105,6 +114,7 @@ Offering this service provides an opportunity to develop and strengthen relation
 Co-PI responsibilities will need to be balanced against other OSPO responsibilities. OSPOs may risk overcommitment if co-PI opportunities rapidly multiply.
 
 ## Known Instances
+
 * [The GW Open Source Program Office](https://ospo.gwu.edu/), The George Washington University
 * [Georgia Tech Open Source Program Office](https://ospo.cc.gatech.edu/), Georgia Institute of Technology
 * [Open Source with SLU](https://oss-slu.github.io/), Saint Louis University
@@ -114,12 +124,13 @@ Co-PI responsibilities will need to be balanced against other OSPO responsibilit
 ## References
 
 ### Related Patterns
+
 * [Supporting grant proposals with an open source component](./supporting-grant-proposals-with-an-open-source-component.md)
 * [Open Source Grant Commitment Letter](./open-source-grant-commitment-letter.md)
 * [OSPO as *Lead* Principal Investigator](./ospo-as-lead-principal-investigator.md)
 
 ## Contributors & Acknowledgement
-* Ciara Flanagan, https://orcid.org/0009-0005-3153-7673
+
+* Ciara Flanagan, <https://orcid.org/0009-0005-3153-7673>
 
 *Thanks to all the CURIOSS members who identified this pattern at the 2025 CURIOSS Winter Gathering.*
-

--- a/ospo-as-lead-principal-investigator.md
+++ b/ospo-as-lead-principal-investigator.md
@@ -10,22 +10,26 @@ tags:
 # OSPO as *Lead* Principal Investigator
 
 ## Pattern Summary
+
 Leverage OSPO staff’s open source expertise skills to address relevant issues as lead Principal Investigators (PIs) on funding proposals.
 
 ## Problem / Challenge
+
 There has been a growth in recognition of the value of open source software amongst funders. Increasingly, funders require software to be released as open source and to make research outputs publicly available.
 
 However, research proposals do not tend to focus on the development of foundational or sustainable infrastructure that serves a wide range of scientific communities.
 
 ## Pattern Category
+
 - Advocacy, Governance & Policy
 - Demonstrating value as an Academic OSPO
 - Funding & Financial Support
 - Open Source Development
 - Open Source Sustainability
 - Promoting Best Practices
-   
+
 ## Context
+
 A university or research institution that submits grant proposals to federal, state or private funding sources.
 
 OSPOs have established credibility through successful support of multiple grant proposals.
@@ -33,14 +37,17 @@ OSPOs have established credibility through successful support of multiple grant 
 An OSPO with the resources/capacity for staff to take on PI leadership responsibilities.
 
 ## Forces
+
 Growing funder emphasis on open science practices and reproducibility.
 
 The OSPO and/or specific OSPO staff have a track record of successful open source project management.
 
 ## Solution
+
 Apply for funding as the lead PI for projects that are crucial to supporting the sustainability and/or reproducibility of research infrastructure and outputs.
 
 ## Resulting Context
+
 The OSPO has an opportunity to deliver demonstration projects that showcase the impact of open source best practices.
 
 The OSPO independently secures funding streams that may support its sustainability as an organization.
@@ -50,18 +57,20 @@ The institution develops a stronger reputation for open science leadership.
 PI responsibilities will need to be balanced against other OSPO responsibilities. OSPOs may risk overcommitment if PI opportunities rapidly multiply.
 
 ## Known Instances
-* [Georgia Tech Open Source Program Office](https://ospo.cc.gatech.edu/), Georgia Institute of Technology
-* [JHU Open Source Programs Office](https://ospo.library.jhu.edu/), Sheridan Libraries, Johns Hopkins University   
-* [UC Santa Cruz OSPO](https://ucsc-ospo.github.io/), University of California Santa Cruz, [UC OSPO Network](https://ucospo.net/)  
+
+- [Georgia Tech Open Source Program Office](https://ospo.cc.gatech.edu/), Georgia Institute of Technology
+- [JHU Open Source Programs Office](https://ospo.library.jhu.edu/), Sheridan Libraries, Johns Hopkins University
+- [UC Santa Cruz OSPO](https://ucsc-ospo.github.io/), University of California Santa Cruz, [UC OSPO Network](https://ucospo.net/)  
 
 ## References
 
 ### Related patterns
-* [OSPO as Co-Principal Investigator](./ospo-as-co-principal-investigator.md)
-* [Supporting grant proposals with an open source component](./supporting-grant-proposals-with-an-open-source-component.md)
+
+- [OSPO as Co-Principal Investigator](./ospo-as-co-principal-investigator.md)
+- [Supporting grant proposals with an open source component](./supporting-grant-proposals-with-an-open-source-component.md)
 
 ## Contributors & Acknowledgement
-* Ciara Flanagan, https://orcid.org/0009-0005-3153-7673
+
+- Ciara Flanagan, <https://orcid.org/0009-0005-3153-7673>
 
 *Thanks to all the CURIOSS members who identified this pattern at the 2025 CURIOSS Winter Gathering.*
-

--- a/ospo-mailing-list.md
+++ b/ospo-mailing-list.md
@@ -13,9 +13,9 @@ Create a mailing list to maintain awareness of the OSPO and to promote engagemen
 
 ## Problem / Challenge
 
-Academic OSPOs need to maintain visibility and demonstrate value to diverse stakeholders (e.g. university leadership, alumni and external partners). 
+Academic OSPOs need to maintain visibility and demonstrate value to diverse stakeholders (e.g. university leadership, alumni and external partners).
 
-These stakeholders are likely to be interested in the OSPO's work but don't have time or inclination to follow detailed discussions. 
+These stakeholders are likely to be interested in the OSPO's work but don't have time or inclination to follow detailed discussions.
 
 OSPOs also need a simple entry point for students, researchers, open source projects and potential contributors who want to learn more about potential opportunities.
 
@@ -25,7 +25,7 @@ OSPOs also need a simple entry point for students, researchers, open source proj
 - Awareness
 - Community Building
 - Demonstrating value as an OSPO
-   
+
 ## Context
 
 A university or research institution creating large volumes of research outputs across every discipline.
@@ -33,63 +33,72 @@ A university or research institution creating large volumes of research outputs 
 An OSPO has been established and may be at an early stage of its development.
 
 ## Forces
+
 OSPO staff may not have the time and resources to produce a newsletter on a regular basis.
 
-Stakeholders are busy people who receive many emails and may quickly unsubscribe from anything that wastes their time. 
+Stakeholders are busy people who receive many emails and may quickly unsubscribe from anything that wastes their time.
 
 The university may have existing mailing list platforms and brand guidelines that must be followed.
 
 ## Solution
+
 Create an OSPO mailing list to communicate important information to OSPO stakeholders.
 
 ### Gathering subscribers
-Subscribers can be added or identified in a number of ways: 
 
-* Adding a join button to the OSPO website.
-* Providing an opt-in for attendees during registration for OSPO events.
-* Providing a join link on any email/digital communications from the wider university.
-* Providing an opt-out via self-subscription on the wider university lists service.
-* Direct promotion of the newsletter to interested groups on campus (e.g. tech groups, coder clubs etc.).
-* Direct promotion of the mailing list to maintainers and contributors identified in the discovery process for OSS projects on campus. 
-* Direct promotion of the newsletter to key decision makers and leadership with an opt-in (or simple opt-out) to join.
+Subscribers can be added or identified in a number of ways:
+
+- Adding a join button to the OSPO website.
+- Providing an opt-in for attendees during registration for OSPO events.
+- Providing a join link on any email/digital communications from the wider university.
+- Providing an opt-out via self-subscription on the wider university lists service.
+- Direct promotion of the newsletter to interested groups on campus (e.g. tech groups, coder clubs etc.).
+- Direct promotion of the mailing list to maintainers and contributors identified in the discovery process for OSS projects on campus.
+- Direct promotion of the newsletter to key decision makers and leadership with an opt-in (or simple opt-out) to join.
 
 ### Select tool or platform
-* Liaise with communications colleagues on requirements to use university-approved platforms or tools for mailing lists.
-* If an existing university system for mailing lists is not in place, explore a range of self-hosted solutions.
-* Ensure that the correct settings for permissions are enabled.
+
+- Liaise with communications colleagues on requirements to use university-approved platforms or tools for mailing lists.
+- If an existing university system for mailing lists is not in place, explore a range of self-hosted solutions.
+- Ensure that the correct settings for permissions are enabled.
   
 ### Mailing list content
-Mailing list content should focus on announcements that will be valued by stakeholders, for example: 
 
-* Dates and times for meet ups, training workshops and OSPO events.
-* New services for open source projects.
-* Funding opportunities for open source projects.
-* Calls to Action for open source initiatives.
+Mailing list content should focus on announcements that will be valued by stakeholders, for example:
+
+- Dates and times for meet ups, training workshops and OSPO events.
+- New services for open source projects.
+- Funding opportunities for open source projects.
+- Calls to Action for open source initiatives.
 
 ## Resulting Context
+
 An academic Open Source Program Office (OSPO) gains several strategic benefits from publishing a regular newsletter:
 
-* The mailing list serves as a **regular channel for promoting the OSPO**; signposting support for open source projects and the academic community; and also attracting new contributors/participants to open source projects.
-* Mailing list permissions may enable subscribers to reply directly to both the OSPO and/or all mailing subscribers. This allows greater spontaneous interaction with important audiences.
+- The mailing list serves as a **regular channel for promoting the OSPO**; signposting support for open source projects and the academic community; and also attracting new contributors/participants to open source projects.
+- Mailing list permissions may enable subscribers to reply directly to both the OSPO and/or all mailing subscribers. This allows greater spontaneous interaction with important audiences.
 
 ### Additional Learning from OpenSource@Stanford, Stanford University
-When we originally set up our OSPO, we wanted to communicate important news about the OSPO on campus. However, as a nascent OSPO, we knew that we wouldn’t have regular news about our achievements to share on a monthly cadence. 
+
+When we originally set up our OSPO, we wanted to communicate important news about the OSPO on campus. However, as a nascent OSPO, we knew that we wouldn’t have regular news about our achievements to share on a monthly cadence.
 
 We created our mailing list and use it for important updates and reminders about our events and regular meetings.  
 
 ### Additional learning from the University of California, Santa Barbara OSPO, UC OSPO Network
-We do have a UCSB mailing list. The sign up link is in the newsletter and on our website and in the newsletter itself. 
+
+We do have a UCSB mailing list. The sign up link is in the newsletter and on our website and in the newsletter itself.
 
 In an open source survey that we conducted as part of the OSS discovery process on campus, we included a question where people could consent to be added to the mailing list.
 
 We also advertise our events on other groups' Slacks/Google chats, (e.g. the IT Google group, Women in Tech Google Group, UC-Tech Slack, etc.), which helps boost mailing list sign-ups.
 
-We use [Constant Contact](https://www.brevo.com/landing/constant-contact) as part of the Library Communications Department's license and we use templates created by a staff graphic designer. 
+We use [Constant Contact](https://www.brevo.com/landing/constant-contact) as part of the Library Communications Department's license and we use templates created by a staff graphic designer.
 
 ### Additional Learning from the University of California OSPO Network
-Each campus in the UC network now has their own mailing list. 
 
-Before each campus’s first meetup, we used the results of a GitHub scraping for our repo browser, and sent meetup invites to a subset of that scraping. The 
+Each campus in the UC network now has their own mailing list.
+
+Before each campus’s first meetup, we used the results of a GitHub scraping for our repo browser, and sent meetup invites to a subset of that scraping. The
 
 Principal Investigators on each campus also added relevant people to the invite list.
 
@@ -97,28 +106,28 @@ We didn’t subscribe invitees to the mailing list. They opted-in using a link i
 
 Each campus is using different platforms, including Google Groups and Mailchimp. Apart from UC Santa Barbara, we liaised with the library communications teams on the mailing platforms.
 
-
 ## Known Instances
-* [OpenSource@Stanford](https://opensource.stanford.edu/), Stanford Data Science Center for Open and Reproducible Science (CORES), Leland Stanford Junior University
-* [University of California OSPO Network](https://ucospo.net/)
-* [UC Santa Barbara Open Source Program](https://ucospo.net/santa-barbara/), University of California, Santa Barbara, [University of California OSPO Network](https://ucospo.net/)
 
+- [OpenSource@Stanford](https://opensource.stanford.edu/), Stanford Data Science Center for Open and Reproducible Science (CORES), Leland Stanford Junior University
+- [University of California OSPO Network](https://ucospo.net/)
+- [UC Santa Barbara Open Source Program](https://ucospo.net/santa-barbara/), University of California, Santa Barbara, [University of California OSPO Network](https://ucospo.net/)
 
 ## References
-* Scroll down for the join button at the end of the [UC Santa Barbara Open Source Program home page](https://ucospo.net/santa-barbara/) to be brought to this [sign up page](https://lp.constantcontactpages.com/sl/hlmtgmY/ucsbospo)
+
+- Scroll down for the join button at the end of the [UC Santa Barbara Open Source Program home page](https://ucospo.net/santa-barbara/) to be brought to this [sign up page](https://lp.constantcontactpages.com/sl/hlmtgmY/ucsbospo)
 
 ### Related Patterns
 
-* [Open Source Survey](./open-source-survey.md)
-* [OSPO website](./ospo-website.md)
-* [Publish an OSPO Newsletter](./publish-an-ospo-newsletter.md)
-* [Set up an informal Communication Platform](./set-up-an-informal-communication-platform.md)
+- [Open Source Survey](./open-source-survey.md)
+- [OSPO website](./ospo-website.md)
+- [Publish an OSPO Newsletter](./publish-an-ospo-newsletter.md)
+- [Set up an informal Communication Platform](./set-up-an-informal-communication-platform.md)
 
 ## Contributors & Acknowledgement
 
 In alphabetical order
 
-* Ciara Flanagan, https://orcid.org/0009-0005-3153-7673
-* Francesca Vera, Stanford University, https://orcid.org/0000-0001-8791-3854
-* Laura Langdon, University of California, Davis
-* Virginia Scarlett, University of California, Santa Barbara, https://orcid.org/0000-0002-4156-2849
+- Ciara Flanagan, <https://orcid.org/0009-0005-3153-7673>
+- Francesca Vera, Stanford University, <https://orcid.org/0000-0001-8791-3854>
+- Laura Langdon, University of California, Davis
+- Virginia Scarlett, University of California, Santa Barbara, <https://orcid.org/0000-0002-4156-2849>

--- a/ospo-student-ambassador-program.md
+++ b/ospo-student-ambassador-program.md
@@ -5,18 +5,19 @@ tags:
   - Education & Skills
 ---
 
-# OSPO Student Ambassador Program 
+# OSPO Student Ambassador Program
 
-## Pattern Summary 
+## Pattern Summary
 
-Create a paid Student Ambassador program that empowers undergraduate and graduate students to promote open source engagement, events and projects across the university. 
+Create a paid Student Ambassador program that empowers undergraduate and graduate students to promote open source engagement, events and projects across the university.
 
- # Problem / Challenge
+# Problem / Challenge
+
 An academic OSPO wants to build consistent, authentic connections with the student body while advancing the OSPO’s technical and community goals.
 
-Academic OSPO staff have competing priorities and do not have the necessary time for outreach initiatives that connect directly with students. 
+Academic OSPO staff have competing priorities and do not have the necessary time for outreach initiatives that connect directly with students.
 
-Without proactive outreach, awareness of open source opportunities remains low and student participation in OSPO initiatives will be limited. 
+Without proactive outreach, awareness of open source opportunities remains low and student participation in OSPO initiatives will be limited.
 
 ## Pattern Category
 
@@ -39,11 +40,12 @@ The academic OSPO may lack full-time staff dedicated to outreach.
 
 ## Solution
 
-Create a Student Ambassador program within the OSPO consisting of a small team of paid undergraduate and graduate students (working approximately 10 - 20 hours a week). 
+Create a Student Ambassador program within the OSPO consisting of a small team of paid undergraduate and graduate students (working approximately 10 - 20 hours a week).
 
 The ambassadors serve as liaisons between the OSPO and the student body through designated acitivities.  
 
-Activities to consider may include: 
+Activities to consider may include:
+
 * Creating and managing OSPO social media accounts to share updates and opportunities.
 * Hosting and [tabling at campus events](./event-tabling.md) to promote the OSPO and open source awareness.
 * Organizing community-building activities such as movie nights or coding sessions.
@@ -54,29 +56,30 @@ Activities to consider may include:
 
 Student Ambassador Programs create visible, authentic, student-led initiatives for the OSPO based on peer-to-peer engagement rather than top-down institutional messaging.
 
-Ambassadors increase awareness and participation in open-source initiatives whilst also delivering tangible technical outcomes. 
+Ambassadors increase awareness and participation in open-source initiatives whilst also delivering tangible technical outcomes.
 
 The program presents opportunities for students to develop important soft skills in communications, facilitation, team work and leadership.
 
-A combination of graduate and undergraduate ambassadors creates a sustainable pipeline of Student Ambassadors and maintains consistency as students graduate. It also enables broader coverage across academic levels, strengthens continuity over semesters and meets OSPO workload requirements. 
+A combination of graduate and undergraduate ambassadors creates a sustainable pipeline of Student Ambassadors and maintains consistency as students graduate. It also enables broader coverage across academic levels, strengthens continuity over semesters and meets OSPO workload requirements.
 
-In order to sustain funding for paid positions, measurable program outputs and outcomes should be developed to justify continued university support. The program should also align with both educational and open source values. 
+In order to sustain funding for paid positions, measurable program outputs and outcomes should be developed to justify continued university support. The program should also align with both educational and open source values.
 
-### Additional Learning from the GW Open Source Program Office 
+### Additional Learning from the GW Open Source Program Office
 
 Two graduates (working 20 hours per week) and two undergraduate students (working 10 hours per week) work alongside OSPO staff to promote open source awareness, organize events and contribute to open source infrastructure at GW.
 
-Early results have demonstrated increased event attendance, successful launches of social media channels and ongoing student-led technical projects aimed at promoting open-source use across departments. 
+Early results have demonstrated increased event attendance, successful launches of social media channels and ongoing student-led technical projects aimed at promoting open-source use across departments.
 
 Positions were advertised in the OSPO monthly newsletter and stakeholders were invited to forward or share positions with students. No other advertising was necessary, as students actively monitor the GW Student Employment portal. The pool of applicants was large and the quality of the candidates was very high.
 
 There are many steps involved in the hiring process, including posting the jobs, reviewing applications, conducting interviews, and hiring the ambassadors. It is important to note that the GW OSPO received a lot of help in this process from GW Library staff already familiar with student hiring and management.  
 
-We were able to hire technical as well as communication and marketing team members that work very well together as an open source student outreach team. (The GW OSPO is happy to share details along with our specific job postings.) 
+We were able to hire technical as well as communication and marketing team members that work very well together as an open source student outreach team. (The GW OSPO is happy to share details along with our specific job postings.)
 
 After hiring is complete, OSPOs must consider onboarding for their ambassadors. The University of Vermont’s [ORCA program](./open-research-community-accelerator.md) provides a great starting point for outlining onboarding materials and ambassador expectations.
 
 ## Known Instances
+
 * [GW OSPO](https://ospo.gwu.edu/), George Washington University
 
 ## References
@@ -87,14 +90,15 @@ After hiring is complete, OSPOs must consider onboarding for their ambassadors. 
 * [Undergraduate Student OSPO Ambassador job description](Undergrad%20Ambassador%20position.pdf)
 
 ### Related Patterns
+
 * [Event Tabling](./event-tabling.md)
 * [Open Research Community Accelerator (ORCA)](./open-research-community-accelerator.md)
 * [Student Outreach Strategy](./student-outreach-strategy.md)
 
 ## Contributors & Acknowledgements
 
-Mia Diewald, George Washington University, https://orcid.org/0009-0005-8123-1832
+Mia Diewald, George Washington University, <https://orcid.org/0009-0005-8123-1832>
 
-Rosemary Pauley, George Washington University, https://orcid.org/0009-0008-9354-4301 
+Rosemary Pauley, George Washington University, <https://orcid.org/0009-0008-9354-4301>
 
-Ciara Flanagan, https://orcid.org/0009-0005-3153-7673
+Ciara Flanagan, <https://orcid.org/0009-0005-3153-7673>

--- a/ospo-website.md
+++ b/ospo-website.md
@@ -15,7 +15,8 @@ Establish a website for an Academic Open Source Program Office (OSPO) to communi
 Open source work in academia is usually dispersed across departments, labs, and projects - making it difficult for academic OSPOs to directly communicate with and reach all stakeholders.
 
 Without a transparent, discoverable web presence:
-* The OSPO becomes dependent on personal networks to promote its services and activities. 
+
+* The OSPO becomes dependent on personal networks to promote its services and activities.
 * Potential collaborators will not easily find or understand what the OSPO does.
 * A wider pool of students and researchers may miss opportunities to participate in open source initiatives.
 
@@ -23,10 +24,10 @@ As a result, the OSPO risks invisibility and its potential impact is limited.
 
 ## Pattern Category
 
-- Awareness
-- Community Building
-- Demonstrating value as an OSPO
-   
+* Awareness
+* Community Building
+* Demonstrating value as an OSPO
+
 ## Context
 
 A research institution or a university creating large volumes of research outputs across every discipline.
@@ -59,7 +60,7 @@ Based on the website’s goals, content may cover the following themes:
 
 * **About the OSPO:** Its mission, vision, governance, and team.
 
-* **OSPO Services:** Support and capacity building activities provided by the OSPO. 
+* **OSPO Services:** Support and capacity building activities provided by the OSPO.
 
 * **Projects and Collaboration:** Promotion of active open source projects (e.g. project registry), student programs, internal and external partnerships.
 
@@ -73,19 +74,21 @@ Based on the website’s goals, content may cover the following themes:
 
 * **Resources:** A collection of relevant policies, toolkits and best practices for stakeholders.
 
-### Other areas for consideration:
+### Other areas for consideration
 
 One question to consider may be whether to make the site itself open source.
 
 ## Resulting Context
 
-The OSPO website becomes a central point of discovery and engagement for stakeholders within and outside of its institution. 
+The OSPO website becomes a central point of discovery and engagement for stakeholders within and outside of its institution.
 
 Students, researchers and faculty engaged in open source activity benefit from:
+
 * A central hub of up to date information signposting relevant services and opportunities.
 * Lower barriers to internal and external collaboration.
 
 The OSPO itself benefits from:
+
 * Enhanced institutional visibility and legitimacy of open source work.
 * A platform that consistently communicates its mission and outputs.
 * A public archive of its projects, policies, and impact.
@@ -108,7 +111,7 @@ The OSPO itself benefits from:
 * [Open Source with SLU](https://oss-slu.github.io/), Saint Louis University
 * [Syracuse University OSPO](https://opensource.syracuse.edu/), Syracuse University
 * [TCD Open Source Program Office](https://www.tcd.ie/innovation/knowledge-exchange-office-knex/open-source-programme-office/), Trinity Innovation, Trinity College Dublin
-* [UGA Open Source Program Office ](https://scienceouverte.univ-grenoble-alpes.fr/en/about/codes-data-grenoble-alpes-office/), Université Grenoble Alpes
+* [UGA Open Source Program Office](https://scienceouverte.univ-grenoble-alpes.fr/en/about/codes-data-grenoble-alpes-office/), Université Grenoble Alpes
 * [UC Berkeley OSPO](https://ospo-berkeley-edu.netlify.app/), Berkeley Institute for Data Science, University of California, Berkeley, [UC OSPO Network](https://ucospo.net/)  
 * [UC Davis OSPO](https://ucospo.net/davis/), University of California, Davis, [UC OSPO Network](https://ucospo.net/)  
 * [UC Los Angeles OSPO](https://ucospo.net/los-angeles/), University of California, Los Angeles, [UC OSPO Network](https://ucospo.net/)  
@@ -129,4 +132,4 @@ The OSPO itself benefits from:
 
 ## Contributors & Acknowledgement
 
-* Ciara Flanagan, https://orcid.org/0009-0005-3153-7673
+* Ciara Flanagan, <https://orcid.org/0009-0005-3153-7673>

--- a/oss-tutorials-using-authoring-tools.md
+++ b/oss-tutorials-using-authoring-tools.md
@@ -30,7 +30,7 @@ Education/training content is frequently updated across the university.
 
 Funding bodies are mandating public access to funded research outputs and research software.
 
-Training materials are needed to support academic cohorts to comply with these public funding mandates. 
+Training materials are needed to support academic cohorts to comply with these public funding mandates.
 
 Due to the diverse range of technologies and teaching approaches, training resources must be accessible and easily adapted.
 
@@ -51,14 +51,14 @@ Other tools / platforms such as [Jupyter Book 2](https://blog.jupyterbook.org/po
 
 Workflows can be developed for both tutorials *and* workshops that share content and provide experiential learning opportunities.
 
-The methodology for designing OSS tutorials can serve as an example for promoting the use of OER across departments. 
+The methodology for designing OSS tutorials can serve as an example for promoting the use of OER across departments.
 
 ### Additional Learning from the GW OSPO
 
 An exciting benefit of these interactive and publicly available educational tutorial templates is that they are more dynamic. They enable a new type of continuous open science that more closely matches agile development. Because these resources are designed to enable reproducibility and accessibility, they:
 
 * Foster trust in research.  
-* Increase scientific quality.   
+* Increase scientific quality.
 * Accelerate the pace of discovery and innovation.
 
 ## Known Instances
@@ -68,13 +68,13 @@ An exciting benefit of these interactive and publicly available educational tuto
 
 ## References
 
-* The GW Open Source Program Office: [sample template repository](https://github.com/gw-ospo/jupyter-book-template)   
+* The GW Open Source Program Office: [sample template repository](https://github.com/gw-ospo/jupyter-book-template)
 * [OSS Licensing for Researchers and Educators](https://gw-ospo.github.io/oss-licensing/intro.html) \- example of an open tutorial on OSS best practices  
 * Repository: [version-control-workshop-2024 and supporting materials](https://github.com/gw-ospo/version-control-workshop-2024/tree/main)  
   [Version Control Basics](https://gw-ospo.github.io/version-control-workshop-2024/) \- Workshop and supporting materials  
-* [Training modules for getting started with open source software development](https://github.com/gt-ospo/oss-training) \- examples of an open training notebooks on getting started with OSS   
+* [Training modules for getting started with open source software development](https://github.com/gt-ospo/oss-training) \- examples of an open training notebooks on getting started with OSS
 * Set Your Money on FIRE: [sample template repository](https://github.com/david-lippert/fire)  
-* [Set Your Money on FIRE tutorials](https://david-lippert.github.io/fire/intro.html)   
+* [Set Your Money on FIRE tutorials](https://david-lippert.github.io/fire/intro.html)
 * [2024 URSSI Summer School resources](https://github.com/si2-urssi/summerschool-June2024)  
 
 ## Contributor(s) & Acknowledgment
@@ -87,8 +87,7 @@ Michael Rossetti \- Jupyter Book Template
 
 ## Additional Notes / Related Inspiration
 
-
-**Excerpt from the poem Love is an Emergent Process by Adrien Marie Brown**
+### Excerpt from the poem Love is an Emergent Process by Adrien Marie Brown
 
 i look to the sky  
 taste the wind on my tongue  

--- a/piggyback-onto-a-larger-conference.md
+++ b/piggyback-onto-a-larger-conference.md
@@ -18,16 +18,17 @@ Build the visibility of an academic OSPO by attaching typical conference activit
 An academic OSPO lacks the community size or resources to host its own standalone conference or summit.
 
 ## Pattern Category
+
 - Building University OSS Community
 - OSS Education & Skills
-- Raising awareness 
+- Raising awareness
 - Sharing OSS Best Practices  
 - Supporting OSS development  
 - Working with Tech Transfer / External Partners  
 
 ## Context
 
-A small academic OSPO has been established within a university. 
+A small academic OSPO has been established within a university.
 
 While there is a growing interest in open source among students, faculty and staff, the community is still in its early stages and remains relatively small.
 
@@ -37,71 +38,80 @@ The OSPO’s budget and staff time is constrained.
 
 There is not enough local interest to justify a standalone event.
 
-Larger conferences or summits with relevant audiences take place on campus or within the same city or region. 
+Larger conferences or summits with relevant audiences take place on campus or within the same city or region.
 
 ## Solution
+
 Identify a well-aligned larger event (e.g. a regional tech conference, academic symposium, or open source summit) and propose a co-located session, track, or ‘mini-summit’. This could take the form of a panel, workshop, hackathon or project showcase.
 
-Co-ordinate with the host organizers to secure a time slot and venue space. Leverage their infrastructure, promotion channels and attendee base. 
+Co-ordinate with the host organizers to secure a time slot and venue space. Leverage their infrastructure, promotion channels and attendee base.
 
 ## Resulting Context
-The OSPO gains exposure, establishes credibility, and fosters partnerships - all without the heavy burden of organizing a full-scale event. 
 
-Participation in the larger event also facilitates recruitment and alignment with broader community trends. 
+The OSPO gains exposure, establishes credibility, and fosters partnerships - all without the heavy burden of organizing a full-scale event.
+
+Participation in the larger event also facilitates recruitment and alignment with broader community trends.
 
 ### Additional Learning from SnT Technology Transfer Office
-We wanted to run a summit for open source but we’re a very small community. The population of Luxembourg is 600,000 people. However, there are plenty of open source users. 
 
-We piggybacked onto a much wider larger conference and held a dedicated track for OSPOs. 
+We wanted to run a summit for open source but we’re a very small community. The population of Luxembourg is 600,000 people. However, there are plenty of open source users.
 
-This helped us a lot because the wider conference is well organized. 
+We piggybacked onto a much wider larger conference and held a dedicated track for OSPOs.
+
+This helped us a lot because the wider conference is well organized.
 
 It’s very important to do some research on the audience who attend the wider conference you’re joining up with. This is important for your keynote speaker and also for the other speakers and activities you’re planning.
 
 ### Additional Learning from the GW Open Source Program Office
+
 We have piggybacked with groups internal and external to our university to share expenses and resources and to amplify our open source voice.
 
 We hosted a semi-annual 3-day Research Software Engineering workshop that is run by URSSI.  We paid for lunches and provided space and volunteer technical assistants from our library staff for the event.  As a result, 20 GW students, staff and faculty were able to attend in addition to the 35 other attendees from all over the US.
 
 ### Additional Learning from the Georgia Tech Open Source Program Office
+
 We’ve held a yearly summit for the past two years. In our first year, we piggybacked onto another conference hosted by a very closely related group, the Scientific Software Center. It was particularly useful as it brought the OSPO and our work to a much wider audience - people who weren’t solely focused on open source.
 
 ### Additional Learning from the Vermont Research Open Source Program Office (VERSO)
-We regularly co-organize or provide a supporting role in larger events in order to bring content about open source and our OSPO’s activities to a wider audience. We facilitate a range of activities from speaking, organising talks, hosting tracks on open source to organizing presentations/workshops from external organizations. 
+
+We regularly co-organize or provide a supporting role in larger events in order to bring content about open source and our OSPO’s activities to a wider audience. We facilitate a range of activities from speaking, organising talks, hosting tracks on open source to organizing presentations/workshops from external organizations.
 
 At a smaller scale, we hold OSPO talks with local meet up groups where OSPO staff speak about our activities.
 
 ## Known Instances
-* [SnT Tech Transfer Office](https://www.uni.lu/snt-en/), l’Université du Luxembourg
-* [GW Open Source Program Office](https://ospo.gwu.edu/), George Washington University
-* [Georgia Tech Open Source Program Office](https://ospo.cc.gatech.edu/), Georgia Institute of Technology
-* [UW-Madison Open Source Program Office](https://ospo.wisc.edu/), Data Science Institute, University of Wisconsin-Madison
-* [Vermont Research Open Source Program Office (VERSO)](https://verso.w3.uvm.edu/), University of Vermont
+
+- [SnT Tech Transfer Office](https://www.uni.lu/snt-en/), l’Université du Luxembourg
+- [GW Open Source Program Office](https://ospo.gwu.edu/), George Washington University
+- [Georgia Tech Open Source Program Office](https://ospo.cc.gatech.edu/), Georgia Institute of Technology
+- [UW-Madison Open Source Program Office](https://ospo.wisc.edu/), Data Science Institute, University of Wisconsin-Madison
+- [Vermont Research Open Source Program Office (VERSO)](https://verso.w3.uvm.edu/), University of Vermont
 
 ## References
-* SnT Tech Transfer Office piggybacked onto the [LibreOffice and Open Source Conference 2024](https://www.uni.lu/snt-en/events/open-source-conference-2024/)
-* The GT OSPO collaborated with the Scientific Software Engineering Center to host the [Sustainable Software in Academia](https://ssecenter.cc.gatech.edu/georgia-tech-scientific-software-2024-workshop/) and the [Open Source and Scientific Software Workshop](https://ospo.cc.gatech.edu/ospo-sse-workshop-2025/) in 2025.
-* The UW-Madison OSPO piggybacked on [UW-Madison Innovate Week](https://innovate.wisc.edu/uw-madison-innovate-week/) to run the event, [‘How Open Source Is Fostering Innovation in AI’](https://dsi.wisc.edu/2024/08/27/how-open-source-is-fostering-innovation-in-ai/)).
-* The VERSO OSPO hosted a number of [Strudel workshops and presentations](https://verso.w3.uvm.edu/research-week-2025-strudel-ux-workshops/) as part of the [University of Vermont’s Research Week 2025](https://www.uvm.edu/ovpr/research-week). 
-* The VERSO OSPO also co-hosted the [Data and Open Science Summit 2025](https://verso.w3.uvm.edu/data-open-science-summit/) with a number of other Departments in University of Vermont.
+
+- SnT Tech Transfer Office piggybacked onto the [LibreOffice and Open Source Conference 2024](https://www.uni.lu/snt-en/events/open-source-conference-2024/)
+- The GT OSPO collaborated with the Scientific Software Engineering Center to host the [Sustainable Software in Academia](https://ssecenter.cc.gatech.edu/georgia-tech-scientific-software-2024-workshop/) and the [Open Source and Scientific Software Workshop](https://ospo.cc.gatech.edu/ospo-sse-workshop-2025/) in 2025.
+- The UW-Madison OSPO piggybacked on [UW-Madison Innovate Week](https://innovate.wisc.edu/uw-madison-innovate-week/) to run the event, [‘How Open Source Is Fostering Innovation in AI’](https://dsi.wisc.edu/2024/08/27/how-open-source-is-fostering-innovation-in-ai/)).
+- The VERSO OSPO hosted a number of [Strudel workshops and presentations](https://verso.w3.uvm.edu/research-week-2025-strudel-ux-workshops/) as part of the [University of Vermont’s Research Week 2025](https://www.uvm.edu/ovpr/research-week).
+- The VERSO OSPO also co-hosted the [Data and Open Science Summit 2025](https://verso.w3.uvm.edu/data-open-science-summit/) with a number of other Departments in University of Vermont.
 
 ### Related Patterns
-* [Co-hosting student events](./cohosting-student-events.md)
-* [Facilitate connections at Open Source Conferences](./facilitate-connections-at-open-source-conferences.md)
-* [Host an Open Source Conference](./host-an-open-source-conference.md)
-* [Informal OSPO focus group sessions at Open Source Events](./informal-ospo-focus-groups-at-open-source-events.md)
-* [Secure Sponsorship for an Open Source Conference](./secure-sponsorship-for-an-open-source-conference.md)
-* [Senior Leadership Keynote](./senior-leadership-keynote.md)
-* [Student Showcase Sessions at OSPO Events](./student-showcase-sessions-at-ospo-events.md)
+
+- [Co-hosting student events](./cohosting-student-events.md)
+- [Facilitate connections at Open Source Conferences](./facilitate-connections-at-open-source-conferences.md)
+- [Host an Open Source Conference](./host-an-open-source-conference.md)
+- [Informal OSPO focus group sessions at Open Source Events](./informal-ospo-focus-groups-at-open-source-events.md)
+- [Secure Sponsorship for an Open Source Conference](./secure-sponsorship-for-an-open-source-conference.md)
+- [Senior Leadership Keynote](./senior-leadership-keynote.md)
+- [Student Showcase Sessions at OSPO Events](./student-showcase-sessions-at-ospo-events.md)
 
 ## Contributors & Acknowledgement
+
 In alphabetical order
 
-* Bethany Philbrick, University of Madison-Wisconsin
-* Ciara Flanagan, https://orcid.org/0009-0005-3153-7673
-* David Lippert, George Washington University, https://orcid.org/0009-0003-6444-9595
-* Fang Liu, Georgia Institute of Technology, https://orcid.org/0000-0002-3383-2191 
-* Jacek Plucinski, l’Université du Luxembourg
-* Jeff Young, Georgia Institute of Technology,, https://orcid.org/0000-0001-9841-4057
-* Kendall Fortney, University of Vermont, https://orcid.org/0009-0006-3898-0771
-
+- Bethany Philbrick, University of Madison-Wisconsin
+- Ciara Flanagan, <https://orcid.org/0009-0005-3153-7673>
+- David Lippert, George Washington University, <https://orcid.org/0009-0003-6444-9595>
+- Fang Liu, Georgia Institute of Technology, <https://orcid.org/0000-0002-3383-2191>
+- Jacek Plucinski, l’Université du Luxembourg
+- Jeff Young, Georgia Institute of Technology,, <https://orcid.org/0000-0001-9841-4057>
+- Kendall Fortney, University of Vermont, <https://orcid.org/0009-0006-3898-0771>

--- a/project-rolodex.md
+++ b/project-rolodex.md
@@ -9,11 +9,11 @@ tags:
 
 ## Pattern Summary
 
-Create an outreach script and contact sheet for conducting outreach with potential stakeholders during the initial stages of establishing and promoting an academic OSPO. 
+Create an outreach script and contact sheet for conducting outreach with potential stakeholders during the initial stages of establishing and promoting an academic OSPO.
 
 ## Problem / Challenge
 
-Academic OSPOs, in their formation stage, face a "cold start" problem: they need to build awareness, identify stakeholders and establish credibility before they have a track record of accomplishments. 
+Academic OSPOs, in their formation stage, face a "cold start" problem: they need to build awareness, identify stakeholders and establish credibility before they have a track record of accomplishments.
 
 Without a structured approach to outreach, early conversations risk becoming:
 
@@ -24,11 +24,11 @@ Without a structured approach to outreach, early conversations risk becoming:
 
 ## Pattern Category
 
-- Awareness
-- Community Building
-- Demonstrating value as an OSPO
-- Open Source Discovery
-   
+* Awareness
+* Community Building
+* Demonstrating value as an OSPO
+* Open Source Discovery
+
 ## Context
 
 A university or research institution with existing open source activities that are scattered or informal.
@@ -45,7 +45,7 @@ Resources are limited, requiring efficient and repeatable outreach processes.
 
 ## Solution
 
-Create a structured approach to stakeholder outreach with a script for introductory conversations and a contact sheet for documenting the call. 
+Create a structured approach to stakeholder outreach with a script for introductory conversations and a contact sheet for documenting the call.
 
 ### Conversation Script
 
@@ -55,7 +55,7 @@ A script for initial conversations about the OSPO may include the following
 
 A broad explainer of OSPOs and academic OSPOs. More general information about the specific OSPO in the context of its institution may also be helpful.
 
-The OSPO may also choose to emphasise different aspects of its work that relate to the stakeholder’s domain, for example: 
+The OSPO may also choose to emphasise different aspects of its work that relate to the stakeholder’s domain, for example:
 
 * **Senior Decision Makers:** Open source as an accelerator of innovation, potential for external collaboration.
 * **Faculty/Researchers:** Support for releasing research software, collaboration infrastructure, recognition for open source contributions.
@@ -103,23 +103,24 @@ There are a number of benefits to using this structured approach:
 
 ### Additional learning from JHU Open Source Program Office
 
-We created a contact sheet for everyone - staff, faculty and any other stakeholders that we called in the initial stages of setting up and promoting the OSPO. 
+We created a contact sheet for everyone - staff, faculty and any other stakeholders that we called in the initial stages of setting up and promoting the OSPO.
 
-The sheet contained key details e.g. the name, role, contact details and department. The sheet also contained a set of specific statements/questions for those introductory conversations. 
+The sheet contained key details e.g. the name, role, contact details and department. The sheet also contained a set of specific statements/questions for those introductory conversations.
 
-We also developed a full set of questions that we included in the contact sheet. We never asked one person all of the questions on the list. Instead, we asked questions that related to what folks were interested in. 
+We also developed a full set of questions that we included in the contact sheet. We never asked one person all of the questions on the list. Instead, we asked questions that related to what folks were interested in.
 
 The questions we used were:
-* Tell me a little about your work 
-* What are the biggest challenges you face when using OSS in research? Teaching? 
-* What kind of support would you find most helpful from an OSPO? 
+
+* Tell me a little about your work
+* What are the biggest challenges you face when using OSS in research? Teaching?
+* What kind of support would you find most helpful from an OSPO?
 * What kind of training or workshops would you be interested in attending?  
-* What kind of training or workshops might be useful for your students? 
-* What kind of resources would you like to see the OSPO provide, such as docs, tools, best practices? 
-* How would you like the OSPO to engage with the broader open source community? City of Baltimore? 
-* Would you like the OSPO to help facilitate engagement with the broader open source community? 
+* What kind of training or workshops might be useful for your students?
+* What kind of resources would you like to see the OSPO provide, such as docs, tools, best practices?
+* How would you like the OSPO to engage with the broader open source community? City of Baltimore?
+* Would you like the OSPO to help facilitate engagement with the broader open source community?
 * Do you need assistance with license selection? Workshop or training on same?
-* Do you need assistance with tech transfer – choosing whether to open source, whether to monetize? 
+* Do you need assistance with tech transfer – choosing whether to open source, whether to monetize?
 * Do you want the OSPO to be an advocate for OSS? At what level – students, faculty, research, admin?
 
 #### Tell me “Two More People”
@@ -134,7 +135,7 @@ We asked everyone to suggest two more people that we should talk to. This was ve
 
 In alphabetical order
 
-* Ciara Flanagan, https://orcid.org/0009-0005-3153-7673
-* Megan Forbes, Johns Hopkins University, https://orcid.org/0000-0002-2611-1441
+* Ciara Flanagan, <https://orcid.org/0009-0005-3153-7673>
+* Megan Forbes, Johns Hopkins University, <https://orcid.org/0000-0002-2611-1441>
   
 A very special thanks to Megan Forbes (Johns Hopkins University OSPO) for sharing this pattern and the title at the CURIOSS Gathering in Vermont (2024).

--- a/publish-an-ospo-newsletter.md
+++ b/publish-an-ospo-newsletter.md
@@ -12,7 +12,7 @@ Create a regular, curated newsletter to maintain awareness of and engagement wit
 
 ## Problem / Challenge
 
-Academic OSPOs need to maintain visibility and demonstrate value to diverse stakeholders (e.g. university leadership, alumni and external partners). These stakeholders are likely to be interested in the OSPO's work but don't have time or inclination to follow detailed discussions. 
+Academic OSPOs need to maintain visibility and demonstrate value to diverse stakeholders (e.g. university leadership, alumni and external partners). These stakeholders are likely to be interested in the OSPO's work but don't have time or inclination to follow detailed discussions.
 
 OSPOs also need a simple entry point for students, researchers, open source projects and potential contributors who want to learn more about potential opportunities.
 
@@ -24,7 +24,7 @@ Without regular, digestible updates, the OSPO risks becoming invisible and losin
 - Awareness
 - Community Building
 - Demonstrating value as an OSPO
-   
+
 ## Context
 
 A university or research institution creating large volumes of research outputs across every discipline.
@@ -33,7 +33,7 @@ An OSPO has been established.
 
 ## Forces
 
-Stakeholders are busy people who receive many emails and may quickly unsubscribe from anything that wastes their time. 
+Stakeholders are busy people who receive many emails and may quickly unsubscribe from anything that wastes their time.
 
 The university may have existing newsletter platforms and brand guidelines that must be followed.
 
@@ -45,40 +45,42 @@ Publish a regular newsletter to raise awareness and visibility of the OSPO.
 
 ### Gathering subscribers
 
-Subscribers can be added or identified in a number of ways: 
-* Adding a join button to the OSPO website.
-* Providing an opt-in for attendees during registration for OSPO events.
-* Providing a join link on any email/digital communications from the wider university (including the newsletter itself).
-* Providing an opt-out via self-subscription on the wider university lists service.
-* Direct promotion of the newsletter to interested groups on campus (e.g. tech groups, coder clubs etc.)
-* Direct promotion of the newsletter to maintainers and contributors identified in the discovery process for OSS projects on campus. 
-* Direct promotion of the newsletter to key decision makers and leadership with an opt-in (or simple opt-out) to join.
+Subscribers can be added or identified in a number of ways:
 
-Subscription opt-in should include a clear description of the frequency and content of the newsletter. 
+- Adding a join button to the OSPO website.
+- Providing an opt-in for attendees during registration for OSPO events.
+- Providing a join link on any email/digital communications from the wider university (including the newsletter itself).
+- Providing an opt-out via self-subscription on the wider university lists service.
+- Direct promotion of the newsletter to interested groups on campus (e.g. tech groups, coder clubs etc.)
+- Direct promotion of the newsletter to maintainers and contributors identified in the discovery process for OSS projects on campus.
+- Direct promotion of the newsletter to key decision makers and leadership with an opt-in (or simple opt-out) to join.
+
+Subscription opt-in should include a clear description of the frequency and content of the newsletter.
 
 A prominent unsubscribe option should also be included in all newsletters.
 
 ### Select tool or platform
 
-* Liaise with communications colleagues on requirements to use university-approved platforms or tools for newsletters.
-* If an existing university system for newsletters is not in place, explore a range of self-hosted solutions.
+- Liaise with communications colleagues on requirements to use university-approved platforms or tools for newsletters.
+- If an existing university system for newsletters is not in place, explore a range of self-hosted solutions.
 
 ### Plan content and format of newsletter
 
 The content and format of the newsletter should take into account the OSPO’s priorities, its audience and the staff time available to produce the newsletter on a regular basis.
 
-A regular newsletter may contain some or all of the following content: 
-* **Spotlight/Feature:** One major story, achievement, or community profile.
-* **Highlights:** Brief updates on projects, contributions, or milestones.
-* **Upcoming opportunities:** Events, workshops, contribution requests, important deadlines (bulleted list).
-* **Resources:** 2-3 links to useful tools, guides, or relevant external content.
-* **Call to action:** Clear next step readers can take to engage with OSPO activities.
+A regular newsletter may contain some or all of the following content:
+
+- **Spotlight/Feature:** One major story, achievement, or community profile.
+- **Highlights:** Brief updates on projects, contributions, or milestones.
+- **Upcoming opportunities:** Events, workshops, contribution requests, important deadlines (bulleted list).
+- **Resources:** 2-3 links to useful tools, guides, or relevant external content.
+- **Call to action:** Clear next step readers can take to engage with OSPO activities.
 
 The newsletter also presents an opportunity to model open source practices by actively promoting **contributions from the academic community**. An open source platform inviting updates from the community can be signposted in the newsletter and/or on the OSPO website.
 
 ### Publishing cadence
 
-The publishing cadence should take staff time into consideration. 
+The publishing cadence should take staff time into consideration.
 
 While monthly newsletters tend to be a popular option. Publishing on a semesterly basis may also be an option.
 
@@ -104,33 +106,33 @@ Track basic metrics (open rates, click-throughs) to understand engagement.
 
 An academic Open Source Program Office (OSPO) gains several strategic benefits from publishing a regular newsletter:
 
-* **Increasing visibility of the OSPO and its services:** The newsletter serves as a regular channel for promoting the OSPO, signposting supports for open source projects and the academic community; and also attracting new contributors/participants to open source projects.
-* **Showcasing the OSPO’s impact and value:** The newsletter can be used as a vehicle to amplify the OSPO’s contributions to the academic community and the wider institution.
-* **Communicating the importance of open source as a research tool/artifact:** Newsletter articles can highlight how open source work connects to research, teaching, and the institution's mission.
+- **Increasing visibility of the OSPO and its services:** The newsletter serves as a regular channel for promoting the OSPO, signposting supports for open source projects and the academic community; and also attracting new contributors/participants to open source projects.
+- **Showcasing the OSPO’s impact and value:** The newsletter can be used as a vehicle to amplify the OSPO’s contributions to the academic community and the wider institution.
+- **Communicating the importance of open source as a research tool/artifact:** Newsletter articles can highlight how open source work connects to research, teaching, and the institution's mission.
 
 ### Additional Learning from the Advanced Research Computing Centre (ARC), University College of London
 
-We have a general mailing list, which covers everything ARC does - not just the OSPO. 
+We have a general mailing list, which covers everything ARC does - not just the OSPO.
 
-We have a join button on our website and we also offer an opt-in for the newsletter in our event registrations. 
+We have a join button on our website and we also offer an opt-in for the newsletter in our event registrations.
 
 Our newsletter is published once a month with room for sending out-of-schedule messages for events that wouldn't be practical to advertise on the newsletter day.
 
 ### Additional learning from the University of California, Santa Barbara OSPO, UC OSPO Network
 
-The sign up link to the UCSB OSPO newsletter can be found on our website and in the newsletter itself. 
+The sign up link to the UCSB OSPO newsletter can be found on our website and in the newsletter itself.
 
 In an open source survey that we conducted as part of the OSS discovery process on campus, we included a question where people could consent to be added to the mailing list.
 
 We also advertise our events on other groups' Slacks/Google chats, (e.g. the IT Google group, Women in Tech Google Group, UC-Tech Slack, etc.), which helps boost mailing list sign-ups.
 
-We use [Constant Contact](https://www.brevo.com/landing/constant-contact) as part of the Library Communications Department's license and we use templates created by a staff graphic designer. 
+We use [Constant Contact](https://www.brevo.com/landing/constant-contact) as part of the Library Communications Department's license and we use templates created by a staff graphic designer.
 
 Our newsletter is published on a monthly basis with a brief reminder email the day before our monthly meetups. All other announcements go on Slack.
 
 ### Additional Learning from the University of California OSPO Network
 
-Each campus in the UC network now has their own mailing list. 
+Each campus in the UC network now has their own mailing list.
 
 Before each campus’s first meetup, we used the results of a GitHub scraping for our repo browser, and sent meetup invites to a subset of that scraping. The Principal Investigators on each campus also added relevant people to the invite list.
 
@@ -140,45 +142,45 @@ Each campus is using different platforms, including Google Groups and Mailchimp.
 
 ### Additional Learning from the George Washington University Open Source Program Office
 
-We have a few different categories in our subscribers list: contacts from our stakeholders; attendees and speakers from our Open Source Conferences; students who have directly reached out to us; and a list of student organizations that are related to engineering, coding, computer science etc. 
+We have a few different categories in our subscribers list: contacts from our stakeholders; attendees and speakers from our Open Source Conferences; students who have directly reached out to us; and a list of student organizations that are related to engineering, coding, computer science etc.
 
-We have also added a "join our newsletter" button to our website. This button resulted in about 20 new contacts over a couple of months. 
+We have also added a "join our newsletter" button to our website. This button resulted in about 20 new contacts over a couple of months.
 
 GW's mass email software is [Emma](https://myemma.com/). We have a sub account in the library and we requested access from the GW Comms Team.
 
-We send out a once monthly newsletter and sporadic announcement emails for various events/workshops. 
+We send out a once monthly newsletter and sporadic announcement emails for various events/workshops.
 
 ### Additional Learning from the University of Texas OSPO
 
-We used a discovery process to find OSS projects on campus and added all relevant emails. 
+We used a discovery process to find OSS projects on campus and added all relevant emails.
 
-We also have an add button on our website and are findable and open to all in the UT Austin lists service. 
+We also have an add button on our website and are findable and open to all in the UT Austin lists service.
 
-We also collect emails from all events and add everyone who attends. 
+We also collect emails from all events and add everyone who attends.
 
-We do not use a formal template but we have our own ‘homegrown’ format where we use or adapt sections from the previous newsletter. 
+We do not use a formal template but we have our own ‘homegrown’ format where we use or adapt sections from the previous newsletter.
 
 UT has a lists service through the central IT office. We use that lists service. Our central communications team does use [Emma](https://myemma.com/) for campus wide communications, but we don’t use the central communications team or software.
 
-We publish each semester and we also announce training, events, funding opportunities, requests for partnership/help on the list when appropriate. 
+We publish each semester and we also announce training, events, funding opportunities, requests for partnership/help on the list when appropriate.
 
 We also provide a sharing function for people subscribed to the list.
 
 ## Known Instances
 
-* [Advanced Research Computing Centre](https://www.ucl.ac.uk/advanced-research-computing/), University College London
-* [GW OSPO](https://ospo.gwu.edu/), George Washington University
-* [University of California OSPO Network](https://ucospo.net/)
-* [UC Santa Barbara Open Source Program](https://ucospo.net/santa-barbara/), University of California, Santa Barbara, [University of California OSPO Network](https://ucospo.net/)
-* [The University of Texas OSPO (UT-OSPO)](https://opensource.utexas.edu/), University of Texas at Austin
+- [Advanced Research Computing Centre](https://www.ucl.ac.uk/advanced-research-computing/), University College London
+- [GW OSPO](https://ospo.gwu.edu/), George Washington University
+- [University of California OSPO Network](https://ucospo.net/)
+- [UC Santa Barbara Open Source Program](https://ucospo.net/santa-barbara/), University of California, Santa Barbara, [University of California OSPO Network](https://ucospo.net/)
+- [The University of Texas OSPO (UT-OSPO)](https://opensource.utexas.edu/), University of Texas at Austin
 
 ## References
 
 ### Links to Academic OSPO Newsletter join buttons and registration pages
 
-* [Joining page](https://www.ucl.ac.uk/advanced-research-computing/community-events/digital-research-community-newsletter) for ARC’s Digital Research Community Newsletter. 
-* Scroll to [What We Do](https://ospo.gwu.edu/) for the join button to be brought to this [registration page](https://ospo.gwu.edu/form/newsletter-opt-in)
-* Scroll down for the join button at the end of the [UC Santa Barbara Open Source Program home page](https://ucospo.net/santa-barbara/) to be brought to this [sign up page](https://lp.constantcontactpages.com/sl/hlmtgmY/ucsbospo)
+- [Joining page](https://www.ucl.ac.uk/advanced-research-computing/community-events/digital-research-community-newsletter) for ARC’s Digital Research Community Newsletter.
+- Scroll to [What We Do](https://ospo.gwu.edu/) for the join button to be brought to this [registration page](https://ospo.gwu.edu/form/newsletter-opt-in)
+- Scroll down for the join button at the end of the [UC Santa Barbara Open Source Program home page](https://ucospo.net/santa-barbara/) to be brought to this [sign up page](https://lp.constantcontactpages.com/sl/hlmtgmY/ucsbospo)
 
 ### Links to open source newsletters providing options for contributions
 
@@ -186,18 +188,19 @@ A sample of [TODO Group’s OSPO News](https://email.linuxfoundation.org/osponew
 
 ### Related Patterns
 
-* [Open Source Survey](./open-source-survey.md)
-* [OSPO Mailing List](./ospo-mailing-list.md)
-* [OSPO Website](./ospo-website.md)
-* [Set up an informal Communication Platform](./set-up-an-informal-communication-platform.md)
+- [Open Source Survey](./open-source-survey.md)
+- [OSPO Mailing List](./ospo-mailing-list.md)
+- [OSPO Website](./ospo-website.md)
+- [Set up an informal Communication Platform](./set-up-an-informal-communication-platform.md)
 
 ## Contributors & Acknowledgement
 
 In alphabetical order:
-* Angela Newell, University of Texas at Austin
-* Ciara Flanagan, https://orcid.org/0009-0005-3153-7673
-* David Lippert, George Washington University, https://orcid.org/0009-0003-6444-9595
-* David Pérez-Suárez, University College London, https://orcid.org/0000-0003-0784-6909
-* Laura Langdon, University of California, Davis
-* Rosemary Pauley, George Washington University, https://orcid.org/0009-0008-9354-4301
-* Virginia Scarlett, University of California, Santa Barbara, https://orcid.org/0000-0002-4156-2849
+
+- Angela Newell, University of Texas at Austin
+- Ciara Flanagan, <https://orcid.org/0009-0005-3153-7673>
+- David Lippert, George Washington University, <https://orcid.org/0009-0003-6444-9595>
+- David Pérez-Suárez, University College London, <https://orcid.org/0000-0003-0784-6909>
+- Laura Langdon, University of California, Davis
+- Rosemary Pauley, George Washington University, <https://orcid.org/0009-0008-9354-4301>
+- Virginia Scarlett, University of California, Santa Barbara, <https://orcid.org/0000-0002-4156-2849>

--- a/secure-sponsorship-for-an-open-source-conference.md
+++ b/secure-sponsorship-for-an-open-source-conference.md
@@ -7,26 +7,31 @@ tags:
 # Secure sponsorship for an Open Source Conference
 
 ## Pattern Summary
+
 Source sponsors to fund an open source conference on campus.
 
 ## Problem / Challenge
-Academic OSPOs often have limited or no dedicated budget for event organization. 
+
+Academic OSPOs often have limited or no dedicated budget for event organization.
 
 The absence of dedicated funding limits the scale of the event.
 
 This, in turn, restricts the ability to showcase the OSPO’s work; promote open source best practices; and drive open source adoption in academia.
 
 ## Pattern Category
+
 - Building University OSS Community
 - Funding & Financial Support
 - Working with Tech Transfer / External Partners  
 
 ## Context
+
 A university with diverse departments of varying levels of OSS expertise and needs.
 
 An OSPO has been established.
 
 ## Forces
+
 Students, researchers and faculty do not know how or where to access information and support from the OSPO that they need.
 
 An OSPO with the capacity to organize / co-organize events.
@@ -36,40 +41,50 @@ Resources may not be available to finance or part-fund the event.
 Member(s) of the conference planning/program committee have useful contacts with local companies, start ups or with organizations in the open source ecosystem.
 
 ## Solution
-Secure event funding by approaching open source companies, organizations and other campus-adjacent businesses as sponsors. 
+
+Secure event funding by approaching open source companies, organizations and other campus-adjacent businesses as sponsors.
 
 The solution below outlines some core activities to consider:
 
 ### Identify Potential Sponsors
+
 Conduct a mapping exercise of potential sponsors including:
-* Local tech companies, startups and campus-adjacent businesses that may benefit from visibility or hiring opportunities.
-* Research open source projects and foundations with funding capacity or community-building mandates.
-* Organizations already interacting with your academic community (e.g., via internships, joint research, GitHub contributions, IT services).
+
+- Local tech companies, startups and campus-adjacent businesses that may benefit from visibility or hiring opportunities.
+- Research open source projects and foundations with funding capacity or community-building mandates.
+- Organizations already interacting with your academic community (e.g., via internships, joint research, GitHub contributions, IT services).
 
 ### Create a Sponsorship Prospectus
+
 Develop a concise, professionally branded sponsorship package that outlines:
-* Event purpose and audience (students, researchers, developers).
-* Sponsorship tiers and benefits (logo placement, speaking slots, booth/table, recruiting access).
-* Impact metrics (expected attendance, demographics, institutional affiliation).
-* A clear call-to-action (how to get involved).
+
+- Event purpose and audience (students, researchers, developers).
+- Sponsorship tiers and benefits (logo placement, speaking slots, booth/table, recruiting access).
+- Impact metrics (expected attendance, demographics, institutional affiliation).
+- A clear call-to-action (how to get involved).
 
 The prospectus should also include alignment with academic values (e.g., open knowledge, inclusion, research impact) to appeal to mission-driven sponsors.
 
 ### Build Personal Connections
-* Leverage faculty, alumni and students with industry connections to make warm introductions.
-* Reach out through LinkedIn, local meetups or previous OSPO collaborators.
+
+- Leverage faculty, alumni and students with industry connections to make warm introductions.
+- Reach out through LinkedIn, local meetups or previous OSPO collaborators.
 
 ### Offer Non-Monetary Support Options
-For companies with limited budgets, provide options to contribute through:
-* In-kind support (venue, swag, food, volunteers, dev tools).
-* Cross-promotion or content contributions (workshops, talks, demos).
 
-### Sponsor relationship management 
+For companies with limited budgets, provide options to contribute through:
+
+- In-kind support (venue, swag, food, volunteers, dev tools).
+- Cross-promotion or content contributions (workshops, talks, demos).
+
+### Sponsor relationship management
+
 Ensure that sponsor logos and acknowledgements are implemented as promised.
 
 Produce a post-event report summarizing impact and thanking sponsors.
 
 ## Resulting Context
+
 There are a wide range of benefits from securing sponsorship for OSPO conferences:
 
 **Increased visibility and credibility for the OSPO and its institution:** A funded and well-run event looks more professional and raises the profile of both the academic OSPO and the broader institution. Sponsors often help promote events through their own channels, which increases impact within relevant communities.
@@ -81,6 +96,7 @@ There are a wide range of benefits from securing sponsorship for OSPO conference
 **Improved conference experience:** More resources translate into more speakers,  better venues, side events and technical infrastructure. This enhances the overall experience for all participants.
 
 ### Additional Learning from the GW Open Source Program Office
+
 We really benefited from our engaged program and planning committee members who had good contacts. Specifically, a key member of our IT department, who is heavily involved in procurement for the university, brought in two sponsors. One of our OSPO leadership also sourced funding from our gold sponsor at a conference. In the future we hope to leverage some alumni connections.
 
 We were able to get impressive keynote speakers from NASA and GW to commit early and we included this in our sponsor prospectus. We were lucky to get sponsors who are (for the most part) good open source community members so they truly contributed to the conference.  
@@ -88,32 +104,37 @@ We were able to get impressive keynote speakers from NASA and GW to commit early
 We also connected to the local OSS community to get speakers and active participants (e.g. CMS, DC Civic Tech, GW projects).
 
 ### Additional learning for the University of California OSPO Network
-We used a lot of our sponsorship to pay for travel costs. Interestingly, this wasn’t just for speakers - it was also for some participants. We were very focused on getting key people in the room together. 
+
+We used a lot of our sponsorship to pay for travel costs. Interestingly, this wasn’t just for speakers - it was also for some participants. We were very focused on getting key people in the room together.
 
 ## Known Instances
-* [GW OSPO](https://ospo.gwu.edu/), George Washington University
-* [UC Santa Cruz OSPO](https://ucsc-ospo.github.io/), University of Santa Cruz, [University of California OSPO Network](https://ucospo.net/events/uc-open-4-2025/)
+
+- [GW OSPO](https://ospo.gwu.edu/), George Washington University
+- [UC Santa Cruz OSPO](https://ucsc-ospo.github.io/), University of Santa Cruz, [University of California OSPO Network](https://ucospo.net/events/uc-open-4-2025/)
 
 ## References
-* [GW OSCON](https://ospo.gwu.edu/oscon-2025) sponsors listed at the end of the page.
-* [Sponsor Prospectus for GW OSCON 2025](https://gwu.box.com/s/t85385ljfie6ixtt0zxx2mnw6nxh40mx).
-* [University of California Open Summit (UC Open) 2025](https://ucospo.net/events/uc-open-4-2025/) sponsors listed above summit agenda.
-* [UC Open Source Research Symposium 2024 Sponsorship Prospectus](https://drive.google.com/file/d/1cgxd-DRan9hC1JV2zefeHuXqWZpcRAsf/view).
+
+- [GW OSCON](https://ospo.gwu.edu/oscon-2025) sponsors listed at the end of the page.
+- [Sponsor Prospectus for GW OSCON 2025](https://gwu.box.com/s/t85385ljfie6ixtt0zxx2mnw6nxh40mx).
+- [University of California Open Summit (UC Open) 2025](https://ucospo.net/events/uc-open-4-2025/) sponsors listed above summit agenda.
+- [UC Open Source Research Symposium 2024 Sponsorship Prospectus](https://drive.google.com/file/d/1cgxd-DRan9hC1JV2zefeHuXqWZpcRAsf/view).
 
 ### Related Patterns
-* [Co-hosting Student Events](./cohosting-student-events.md)
-* [Create a Donor/Sponsorship Prospectus](./create-a-donor-or-sponsorship-prospectus.md)
-* [Facilitate connections at Open Source Conferences](./facilitate-connections-at-open-source-conferences.md)
-* [Host an Open Source Conference](./host-an-open-source-conference.md)
-* [Informal OSPO focus group sessions at Open Source Events](./informal-ospo-focus-groups-at-open-source-events.md)
-* [Piggyback onto a larger conference](piggyback-onto-a-larger-conference.md)
-* [Senior Leadership Keynote](./senior-leadership-keynote.md)
-* [Student Showcase Sessions at OSPO Events](./student-showcase-sessions-at-ospo-events.md)
+
+- [Co-hosting Student Events](./cohosting-student-events.md)
+- [Create a Donor/Sponsorship Prospectus](./create-a-donor-or-sponsorship-prospectus.md)
+- [Facilitate connections at Open Source Conferences](./facilitate-connections-at-open-source-conferences.md)
+- [Host an Open Source Conference](./host-an-open-source-conference.md)
+- [Informal OSPO focus group sessions at Open Source Events](./informal-ospo-focus-groups-at-open-source-events.md)
+- [Piggyback onto a larger conference](piggyback-onto-a-larger-conference.md)
+- [Senior Leadership Keynote](./senior-leadership-keynote.md)
+- [Student Showcase Sessions at OSPO Events](./student-showcase-sessions-at-ospo-events.md)
   
 ## Contributors & Acknowledgement
+
 In alphabetical order:
 
-* Ciara Flanagan, https://orcid.org/0009-0005-3153-7673
-* David Lippert, George Washington University, https://orcid.org/0009-0003-6444-9595
-* Lorena Barba, George Washington University, https://orcid.org/0000-0001-5812-2711
-* Stephanie Lieggi, University of California Santa Cruz, https://orcid.org/0009-0000-5647-6540
+- Ciara Flanagan, <https://orcid.org/0009-0005-3153-7673>
+- David Lippert, George Washington University, <https://orcid.org/0009-0003-6444-9595>
+- Lorena Barba, George Washington University, <https://orcid.org/0000-0001-5812-2711>
+- Stephanie Lieggi, University of California Santa Cruz, <https://orcid.org/0009-0000-5647-6540>

--- a/senior-leadership-keynote.md
+++ b/senior-leadership-keynote.md
@@ -7,26 +7,31 @@ tags:
 # Senior Leadership Keynote
 
 ## Pattern Summary
+
 Secure keynote presentations from senior university leadership at open source conferences to demonstrate institutional commitment and to elevate the profile of open source activities on campus.
 
 ## Problem / Challenge
-Open source initiatives within universities may struggle to gain institutional recognition and legitimacy. 
 
-Open source work may also be viewed as peripheral to the university's core academic mission. 
+Open source initiatives within universities may struggle to gain institutional recognition and legitimacy.
 
-Without visible leadership support, open source conferences risk being seen as niche technical events rather than strategic institutional priorities. 
+Open source work may also be viewed as peripheral to the university's core academic mission.
+
+Without visible leadership support, open source conferences risk being seen as niche technical events rather than strategic institutional priorities.
 
 ## Pattern Category
+
 - Demonstrating value as an OSPO
 - OSS Advocacy & Policy
 - Raising awareness
-   
+
 ## Context
+
 A university with diverse departments of varying levels of OSS expertise and needs.
 
 An OSPO has been established.
 
 ## Forces
+
 An OSPO with the capacity to organize / co-organize events.
 
 A conference has been organized by the OSPO and a program committee is in place.
@@ -40,45 +45,52 @@ External attendees and partners value seeing institutional commitment from the t
 OSPO staff and/or supporters have developed relationships with leadership.
 
 ## Solution
-Approach senior university leadership (president, provost, or relevant vice president) to deliver a keynote address at the open source conference. 
+
+Approach senior university leadership (president, provost, or relevant vice president) to deliver a keynote address at the open source conference.
 
 The theme of the proposed keynote will focus on how open source aligns with the institution's mission, values, and strategic goals.
 
 The OSPO provides talking points and background materials to support leadership to craft a message that resonates with the conference audience.
 
 ## Resulting Context
-The leadership keynote signals strong institutional backing for open source initiatives, lending credibility and importance to the event. 
 
-Faculty and staff see that open source work is valued at the highest levels, potentially increasing their willingness to participate in OSPO programs. 
+The leadership keynote signals strong institutional backing for open source initiatives, lending credibility and importance to the event.
 
-External attendees, including industry partners and other academic institutions, recognize the university as a serious player in open source. 
+Faculty and staff see that open source work is valued at the highest levels, potentially increasing their willingness to participate in OSPO programs.
 
-Media coverage often highlights the leadership participation, raising the university's profile in open source communities. 
+External attendees, including industry partners and other academic institutions, recognize the university as a serious player in open source.
+
+Media coverage often highlights the leadership participation, raising the university's profile in open source communities.
 
 ### Additional learning from Carnegie Mellon University OSPO
+
 The presence of a program officer or director from a funding agency is an important draw for university senior leadership.
 
 ## Known Instances
-* Carnegie Mellon University OSPO, CMU Libraries, Carnegie Mellon University
-* Johns Hopkins University OSPO, Sheridan Libraries, Johns Hopkins University
-* [GW Open Source Program Office](https://ospo.gwu.edu/), The George Washington University
+
+- Carnegie Mellon University OSPO, CMU Libraries, Carnegie Mellon University
+- Johns Hopkins University OSPO, Sheridan Libraries, Johns Hopkins University
+- [GW Open Source Program Office](https://ospo.gwu.edu/), The George Washington University
 
 ## References
+
 Johns Hopkins University OSPO’s [FOSSPROF Summative Event 2024](https://ospo.library.jhu.edu/services/free-and-open-source-software-project-fund-fossprof/fossprof-summative-event/)
 
 ### Related Patterns
-* [Co-hosting student events](./cohosting-student-events.md)
-* [Facilitate connections at Open Source Conferences](./facilitate-connections-at-open-source-conferences.md)
-* [Host an Open Source Conference](./host-an-open-source-conference.md)
-* [Informal OSPO focus group sessions at Open Source Events](./informal-ospo-focus-groups-at-open-source-events.md)
-* [Piggyback onto a larger conference](piggyback-onto-a-larger-conference.md)
-* [Secure Sponsorship for an Open Source Conference](./secure-sponsorship-for-an-open-source-conference.md)
-* [Student Showcase Sessions at OSPO Events](./student-showcase-sessions-at-ospo-events.md)
+
+- [Co-hosting student events](./cohosting-student-events.md)
+- [Facilitate connections at Open Source Conferences](./facilitate-connections-at-open-source-conferences.md)
+- [Host an Open Source Conference](./host-an-open-source-conference.md)
+- [Informal OSPO focus group sessions at Open Source Events](./informal-ospo-focus-groups-at-open-source-events.md)
+- [Piggyback onto a larger conference](piggyback-onto-a-larger-conference.md)
+- [Secure Sponsorship for an Open Source Conference](./secure-sponsorship-for-an-open-source-conference.md)
+- [Student Showcase Sessions at OSPO Events](./student-showcase-sessions-at-ospo-events.md)
 
 ## Contributors & Acknowledgement
+
 In alphabetical order
 
-* Bill Branan, Johns Hopkins University, https://orcid.org/0000-0002-4735-6624
-* Ciara Flanagan, https://orcid.org/0009-0005-3153-7673
-* Megan Forbes, Johns Hopkins University, https://orcid.org/0000-0002-2611-1441
-* Sayeed Choudhury, Carnegie Mellon University, https://orcid.org/0000-0003-2891-0543
+- Bill Branan, Johns Hopkins University, <https://orcid.org/0000-0002-4735-6624>
+- Ciara Flanagan, <https://orcid.org/0009-0005-3153-7673>
+- Megan Forbes, Johns Hopkins University, <https://orcid.org/0000-0002-2611-1441>
+- Sayeed Choudhury, Carnegie Mellon University, <https://orcid.org/0000-0003-2891-0543>

--- a/set-up-an-informal-communication-platform.md
+++ b/set-up-an-informal-communication-platform.md
@@ -12,7 +12,7 @@ Set up a a dedicated communication platform to provide students with a dedicated
 
 ## Problem / Challenge
 
-Students and researchers interested in open source sometimes face barriers to participation. There may not be clear pathways to connect with experienced contributors. Potential contributors may struggle to find appropriate projects matching their skill levels. Those who are new to open source, may lack the confidence to interact publicly with open source communities. 
+Students and researchers interested in open source sometimes face barriers to participation. There may not be clear pathways to connect with experienced contributors. Potential contributors may struggle to find appropriate projects matching their skill levels. Those who are new to open source, may lack the confidence to interact publicly with open source communities.
 
 Standard communication channels (e.g. email or learning management systems) don't reflect the conversational, collaborative nature of open source culture.
 
@@ -22,7 +22,7 @@ OSPOs need an accessible entry point for students, researchers, open source proj
 
 - Awareness
 - Community Building
-   
+
 ## Context
 
 A university or research institution creating large volumes of research outputs across every discipline.
@@ -39,7 +39,7 @@ OSPO staff members have the resources/capacity to maintain and moderate any comm
 
 ## Solution
 
-Set up a dedicated communications platform as an accessible, informal space where students and researchers can ask questions, share information and learn about open source activities taking place across campus. 
+Set up a dedicated communications platform as an accessible, informal space where students and researchers can ask questions, share information and learn about open source activities taking place across campus.
 
 Choose from a range of platforms e.g. [Slack](https://slack.com/), [Discord](https://discord.com/), [Matrix](https://matrix.org/), [Zulip](https://zulip.com/).
 
@@ -60,6 +60,7 @@ The OSPO can identify emerging themes or needs from discussions.
 ### Additional Learning from the University of California OSPO Network
 
 We recently set up a Slack workspace for the network as a whole, and some campuses have set up channels on that workspace for campus-specific chat. The workspace has channels for the following:
+
 - Funding
 - General (read-only for non-admins, so notifications aren’t just noise)
 - Intros
@@ -76,28 +77,28 @@ OpenSource@Stanford has its own Slack workspace where we invite community member
 
 ## Known Instances
 
-* [OpenSource@Stanford](https://opensource.stanford.edu/), Stanford Data Science Center for Open and Reproducible Science (CORES), Leland Stanford Junior University
-* [Open Source with SLU](https://oss-slu.github.io/), Saint Louis University
-* [University of California OSPO Network](https://ucospo.net/)
+- [OpenSource@Stanford](https://opensource.stanford.edu/), Stanford Data Science Center for Open and Reproducible Science (CORES), Leland Stanford Junior University
+- [Open Source with SLU](https://oss-slu.github.io/), Saint Louis University
+- [University of California OSPO Network](https://ucospo.net/)
 
 ## References
 
-* [Example Code of Conduct for Online Discussion Forums](https://www.liverpool.ac.uk/media/livacuk/centre-for-innovation-in-education/diy-guides/example-code-of-conduct-online-discussion-forums/example-code-of-conduct-for-online-discussion-forums.pdf), Centre for Innovation in Education, University of Liverpool
-* [Contributor Covenant](https://www.contributor-covenant.org/), A Code of Conduct for Digital Communities
-* Scroll down to [Getting Started Contributing Code](https://oss-slu.github.io/connect_with/community) for the join button for Open Source with SLU's slack workspace.
-* The join button for the UC OSPO's slack workspace is at the top of [this page](https://ucospo.net/).
+- [Example Code of Conduct for Online Discussion Forums](https://www.liverpool.ac.uk/media/livacuk/centre-for-innovation-in-education/diy-guides/example-code-of-conduct-online-discussion-forums/example-code-of-conduct-for-online-discussion-forums.pdf), Centre for Innovation in Education, University of Liverpool
+- [Contributor Covenant](https://www.contributor-covenant.org/), A Code of Conduct for Digital Communities
+- Scroll down to [Getting Started Contributing Code](https://oss-slu.github.io/connect_with/community) for the join button for Open Source with SLU's slack workspace.
+- The join button for the UC OSPO's slack workspace is at the top of [this page](https://ucospo.net/).
 
 ### Related Patterns
 
-* [Maintainers & Contributors Roundtable](./maintainers-and-contributors-roundtable.md)
-* [OSPO Mailing List](./ospo-mailing-list.md)
-* [OSPO Website](./ospo-website.md)
-* [Publish an OSPO Newsletter](./publish-an-ospo-newsletter.md)
+- [Maintainers & Contributors Roundtable](./maintainers-and-contributors-roundtable.md)
+- [OSPO Mailing List](./ospo-mailing-list.md)
+- [OSPO Website](./ospo-website.md)
+- [Publish an OSPO Newsletter](./publish-an-ospo-newsletter.md)
 
 ## Contributors & Acknowledgement
 
 In alphabetical order
 
-* Ciara Flanagan, https://orcid.org/0009-0005-3153-7673
-* Francesca Vera, Stanford University, https://orcid.org/0000-0001-8791-3854
-* Laura Langdon, University of California, Davis
+- Ciara Flanagan, <https://orcid.org/0009-0005-3153-7673>
+- Francesca Vera, Stanford University, <https://orcid.org/0000-0001-8791-3854>
+- Laura Langdon, University of California, Davis

--- a/set-up-an-ospo-giving-page.md
+++ b/set-up-an-ospo-giving-page.md
@@ -5,23 +5,28 @@ tags:
 # Set up an OSPO Giving Page
 
 ## Pattern Summary
+
 Channel direct funding to an academic OSPO by setting up a donations or giving page that aligns with the institution’s financial systems.
 
 ## Problem / Challenge
-Academic OSPOs are emerging entities within academia that typically depend on short-term grant funding rather than stable institutional budgets. 
+
+Academic OSPOs are emerging entities within academia that typically depend on short-term grant funding rather than stable institutional budgets.
 
 Unlike traditional university fundraising that often relies on alumni networks and established development offices, OSPOs need to attract support from technology companies, open source foundations, individual developers and other non-traditional academic supporters who may have varying levels of familiarity with university partnership processes.
 
-There are a number of bureaucratic challenges for academic OSPOs seeking to establish accessible donation pathways for potential donors and sponsors: 
+There are a number of bureaucratic challenges for academic OSPOs seeking to establish accessible donation pathways for potential donors and sponsors:
+
 * **Complex financial systems** that discourage spontaneous or smaller contributions from a diverse range of potential funders or sponsors.
 * **A lack of information about how to direct donations to OSPOs** and/or other specialized units on the institution’s website.
 * **A need for transparent financial processes** that meet the institution’s financial compliance obligations.
 * **Potential difficulties in accepting unrestricted funds** that can be deployed flexibly across OSPO priorities and opportunities.
 
 ## Pattern Category
-- Funding & Financial Support
-   
+
+* Funding & Financial Support
+
 ## Context
+
 A research university creating large volumes of research outputs across every discipline.
 
 An OSPO has been established.
@@ -29,6 +34,7 @@ An OSPO has been established.
 A stable budget line for the OSPO and/or open source initiatives may not be established within the institution.
 
 ## Forces
+
 Potential donors and sponsors may not know how to donate directly to the OSPO.
 
 OSPO staff members have the capacity to collaborate with finance colleagues on a solution.
@@ -36,10 +42,12 @@ OSPO staff members have the capacity to collaborate with finance colleagues on a
 Procurement and payment guidelines allow for once-off or flexible donations directly to the OSPO.
 
 ## Solution
+
 Set up an OSPO donations/giving page that complies with the university’s funding requirements.
 
 ### Create Clear Financial Infrastructure
-Contact and/or meet finance colleagues to understand the institution’s processes and requirements for donations. Typical points to consider include: 
+
+Contact and/or meet finance colleagues to understand the institution’s processes and requirements for donations. Typical points to consider include:
 
 * How donations are tracked.
 * Setting up accounts or references for donations to the OSPO.
@@ -48,10 +56,12 @@ Contact and/or meet finance colleagues to understand the institution’s process
 * Protocols for sharing information on the website.
 
 ### Develop a communications strategy and supporting materials
+
 * Develop a strategy for promoting direct donations through the giving page and acknowledging donors on the OSPO’s website, materials and communication platforms.
 * Consider developing a prospectus outlining different donor or sponsorship ‘packages’, options for once-off smaller contributions and information about how donations will be used.
 
-### Set up an OSPO Giving Page
+### Build the giving page
+
 * Create a dedicated page on the OSPO’s website.
 * Ensure the page clearly identifies its purpose.
 * Provide clear instructions for each payment method.
@@ -59,45 +69,54 @@ Contact and/or meet finance colleagues to understand the institution’s process
 * Add any relevant supporting materials e.g. a donation/sponsorship prospectus, information about donation usage and impact.
 
 ## Resulting Context
+
 A dedicated giving page produces positive outcomes for the OSPO, donors and the wider academic institution.
 
 ### Benefits for the OSPO
+
 * Greater opportunities for attracting diversified and sustainable funding streams over time.
 * Increased access to donations from sponsors of all sizes and organizational types.
-* A channel for securing dedicated resources for high profile activities or events. 
+* A channel for securing dedicated resources for high profile activities or events.
 
 ### Benefits for Donors
+
 * Flexible contribution levels from individual donations to major sponsorships.
 * More convenient payment options that fit with organizational processes.
 * A clear understanding of how OSPO contributions will be used.
 * Branding and partnership opportunities that align with sponsors' open source mission.
 
 ### Benefits for the Academic Institution
-* Compliance with university financial policies. 
+
+* Compliance with university financial policies.
 * New revenue streams that support institutional open source initiatives.
 * Potential for enhanced industry/donor relationships as a result of OSPO funding.
 
 ### Additional Learning from University of California Santa Cruz OSPO
-Our [OSPO giving page](https://ucsc-ospo.github.io/bankinfo/) links to our [UCSC donation page](https://give.ucsc.edu/campaigns/38026/donations/new?designation=opensourcesoftwareresearchcross&). It’s very simple at our end and we have used it for industry sponsorship of events. 
+
+Our [OSPO giving page](https://ucsc-ospo.github.io/bankinfo/) links to our [UCSC donation page](https://give.ucsc.edu/campaigns/38026/donations/new?designation=opensourcesoftwareresearchcross&). It’s very simple at our end and we have used it for industry sponsorship of events.
 
 ## Known Instances
+
 * [Open Source with SLU](https://oss-slu.github.io/), Saint Louis University
 * [UC Santa Cruz OSPO](https://ucsc-ospo.github.io/), University of California Santa Cruz, [UC OSPO Network](https://ucospo.net/)  
 
 ## References
+
 * [Open Source with SLU Make a Gift page](https://oss-slu.github.io/connect_with/donate)
 * [University of Santa Cruz OSPO giving page](https://ucsc-ospo.github.io/bankinfo/)
 * [UC Open Source Research Symposium 2024 Sponsorship Prospectus](https://drive.google.com/file/d/1cgxd-DRan9hC1JV2zefeHuXqWZpcRAsf/view)
 * [Sponsor Prospectus for GW OSCON 2025](https://gwu.box.com/s/t85385ljfie6ixtt0zxx2mnw6nxh40mx)
 
 ### Related Patterns
+
 * [Create a Donor/Sponsorship Prospectus](./create-a-donor-or-sponsorship-prospectus.md)
 * [OSPO Website](./ospo-website.md)
 * [Secure sponsorship for an Open Source Conference](./secure-sponsorship-for-an-open-source-conference.md)
 
-
 ## Contributors & Acknowledgement
+
 In alphabetical order
-* Ciara Flanagan, https://orcid.org/0009-0005-3153-7673
-* Lance Albertson, Oregon State University, https://orcid.org/0009-0009-8721-3108
-* Stephanie Lieggi, University of California Santa Cruz, https://orcid.org/0009-0000-5647-6540
+
+* Ciara Flanagan, <https://orcid.org/0009-0005-3153-7673>
+* Lance Albertson, Oregon State University, <https://orcid.org/0009-0009-8721-3108>
+* Stephanie Lieggi, University of California Santa Cruz, <https://orcid.org/0009-0000-5647-6540>

--- a/source-industry-mentors-for-the-icorps-program.md
+++ b/source-industry-mentors-for-the-icorps-program.md
@@ -11,14 +11,17 @@ tags:
 # Source Industry Mentors for the I-Corps program
 
 ## Pattern Summary
+
 Use internal university connections to source industry mentors who can commit to the 40 hour mentoring program requirement needed for the NSF I-Corps training program.
 
 ## Problem / Challenge
-[NSF I-Corps program](https://www.nsf.gov/funding/initiatives/i-corps) funding requires applicants to set up their own [I-Corps Teams](https://www.nsf.gov/funding/initiatives/i-corps/about-teams) consisting of a technical lead, entrepreneurial lead and an industry mentor. 
 
-Faculty may face significant challenges in sourcing industry mentors with the availability and/or expertise who can provide 40 hours of guidance throughout the seven week intensive entrepreneurial training program. 
+[NSF I-Corps program](https://www.nsf.gov/funding/initiatives/i-corps) funding requires applicants to set up their own [I-Corps Teams](https://www.nsf.gov/funding/initiatives/i-corps/about-teams) consisting of a technical lead, entrepreneurial lead and an industry mentor.
+
+Faculty may face significant challenges in sourcing industry mentors with the availability and/or expertise who can provide 40 hours of guidance throughout the seven week intensive entrepreneurial training program.
 
 ## Pattern Category
+
 - Demonstrating value as an OSPO
 - Education & Skills
 - Funding & Financial Support
@@ -28,63 +31,72 @@ Faculty may face significant challenges in sourcing industry mentors with the av
 - Working with Tech Transfer / External Partners
 
 ## Context
-A university or research institution based in the United States. 
+
+A university or research institution based in the United States.
 
 Researcher(s) from the university are eligible to apply for the I-Corps program but are having difficulties in finding an appropriate industry mentor.
 
 ## Forces
+
 An OSPO with the capacity to source mentors on behalf of I-Corps applicants or with the capacity to participate in the program.
 
 ## Solution
+
 Engage with the institution's existing innovation and industry infrastructure to source mentors through warm introductions or established relationships through the following channels:
 
-+ **Technology Transfer Office (TTO):** Leverage relationships with industry partners, licensing contacts and entrepreneurs who have previously commercialized university technologies.
-+ **Innovation and Entrepreneurship Centers:** Colleagues based in these centers may be accepted as industry mentors. Staff will also have contacts and relationships with industry mentors from relevant fields.
-+ **Industry Relations/Corporate Partnerships:** Advisory boards, research sponsors, and strategic partnership contacts may also yield mentors.
-+ **Alumni Networks:** Entrepreneurial alumni (particularly those in startup ecosystems or corporate innovation roles) may have a particular interest in participating as industry mentors.
-+ **Existing Entrepreneurship Programs:** Advisory board members, guest lecturers and faculty based in the institution’s business schools, incubators, accelerators and other entrepreneurship initiatives may provide a useful source of mentors.
-+ **Faculty-Industry Connections:** Explore faculty consulting relationships, sabbatical contacts and collaborative research partners.
+- **Technology Transfer Office (TTO):** Leverage relationships with industry partners, licensing contacts and entrepreneurs who have previously commercialized university technologies.
+- **Innovation and Entrepreneurship Centers:** Colleagues based in these centers may be accepted as industry mentors. Staff will also have contacts and relationships with industry mentors from relevant fields.
+- **Industry Relations/Corporate Partnerships:** Advisory boards, research sponsors, and strategic partnership contacts may also yield mentors.
+- **Alumni Networks:** Entrepreneurial alumni (particularly those in startup ecosystems or corporate innovation roles) may have a particular interest in participating as industry mentors.
+- **Existing Entrepreneurship Programs:** Advisory board members, guest lecturers and faculty based in the institution’s business schools, incubators, accelerators and other entrepreneurship initiatives may provide a useful source of mentors.
+- **Faculty-Industry Connections:** Explore faculty consulting relationships, sabbatical contacts and collaborative research partners.
 
 ### Other actions to consider
-+ Establish a mentor ‘database’ with expertise areas, availability windows and a log of when they were approached to participate.
-+ Develop a brief information guide explaining the I-Corps program, requirements and time commitments. 
-+ Create a standardized industry mentor profile template with the information required for the I-Corps executive summary and proposal.
-+ Devise a process for recognizing and rewarding industry mentors who participate.
+
+- Establish a mentor ‘database’ with expertise areas, availability windows and a log of when they were approached to participate.
+- Develop a brief information guide explaining the I-Corps program, requirements and time commitments.
+- Create a standardized industry mentor profile template with the information required for the I-Corps executive summary and proposal.
+- Devise a process for recognizing and rewarding industry mentors who participate.
 
 ## Resulting Context
-Leveraging established networks (over cold outreach) to source mentors is likely to reduce recruitment time. 
+
+Leveraging established networks (over cold outreach) to source mentors is likely to reduce recruitment time.
 
 Systematic relationship development should support the creation of a sustainable mentor pipeline.
 
 Offering support with I-Corps proposals develops and strengthens relationships with colleagues, faculty, researchers and students.
 
 ### Additional learning from Carnegie Mellon University OSPO
+
 As a staff member of the OSPO, I was able to make the case for applying as the industry mentor. I didn’t need ‘a ton’ of industry experience to fully participate and I was able to support each group to make the connections needed for their required short interviews.
 
 I would say that it was definitely valuable to go through the process as an industry mentor and find out what the training entails.
 
 ### Additional learning from OpenSource@Stanford
-We relied on personal networks and connections made through our [Maintainers & Contributors Roundtable program](https://opensource.stanford.edu/programs/maintainers-contributors-roundtable). 
+
+We relied on personal networks and connections made through our [Maintainers & Contributors Roundtable program](https://opensource.stanford.edu/programs/maintainers-contributors-roundtable).
 
 We found that retired industry experts had more time and availability to commit to the program.
 
 ### Additional Learning from University of California Santa Cruz
+
 We are working with our Innovation and Entrepreneurship Hub staff. They can be part of the team and act as the industry mentor. Our folks have previous I-Corps experience so it is really valuable to have them on the team
 
 ## Known Instances
-* [CMU Open Source Program Office](https://www.library.cmu.edu/services/ospo), CMU Libraries, Carnegie Mellon University
-* [OpenSource@Stanford](https://opensource.stanford.edu/), Stanford Data Science Center for Open and Reproducible Science (CORES), Leland Stanford Junior University
-* [UCSC OSPO](https://ucsc-ospo.github.io/), University of California, Santa Cruz, [UC OSPO Network](https://ucospo.net/)
+
+- [CMU Open Source Program Office](https://www.library.cmu.edu/services/ospo), CMU Libraries, Carnegie Mellon University
+- [OpenSource@Stanford](https://opensource.stanford.edu/), Stanford Data Science Center for Open and Reproducible Science (CORES), Leland Stanford Junior University
+- [UCSC OSPO](https://ucsc-ospo.github.io/), University of California, Santa Cruz, [UC OSPO Network](https://ucospo.net/)
 
 ## References
 
 ## Contributors & Acknowledgement
+
 In alphabetical order
 
-* Ciara Flanagan, https://orcid.org/0009-0005-3153-7673
-* Stephanie Lieggi, University of California Santa Cruz, https://orcid.org/0009-0000-5647-6540
-* Tom Hughes, Carnegie Mellon University, https://orcid.org/0009-0008-7516-3687
-* Zach Chandler, Stanford University, https://orcid.org/0000-0003-2402-9839](https://orcid.org/0000-0003-2402-9839
+- Ciara Flanagan, <https://orcid.org/0009-0005-3153-7673>
+- Stephanie Lieggi, University of California Santa Cruz, <https://orcid.org/0009-0000-5647-6540>
+- Tom Hughes, Carnegie Mellon University, <https://orcid.org/0009-0008-7516-3687>
+- Zach Chandler, Stanford University, <https://orcid.org/0000-0003-2402-9839>](<https://orcid.org/0000-0003-2402-9839>
 
 Special thanks to Jeffrey Young (Georgia Tech OSPO) for kickstarting a group discussion on sourcing industry mentors for the I-Corps program.
-

--- a/student-outreach-strategy.md
+++ b/student-outreach-strategy.md
@@ -28,7 +28,7 @@ Without proactive outreach, awareness of open source opportunities remains low a
 
 A research university creating large volumes of research outputs across every discipline.
 
-An OSPO has been established. 
+An OSPO has been established.
 
 The OSPO may lack full-time staff dedicated to outreach.
 
@@ -47,13 +47,13 @@ The solution below outlines some activities to consider:
 
 ### Hire Student Ambassadors
 
-Recruit [Student Ambassadors](./ospo-student-ambassador-program.md) who are familiar with open source and community building. 
+Recruit [Student Ambassadors](./ospo-student-ambassador-program.md) who are familiar with open source and community building.
 
-Student Ambassadors can educate their fellow students in peer-to-peer interactions, with approaches that are personalized and less intimidating than information heavy emails or lectures. 
+Student Ambassadors can educate their fellow students in peer-to-peer interactions, with approaches that are personalized and less intimidating than information heavy emails or lectures.
 
 ### Create Social Media accounts
 
-Build a community on popular social media platforms to connect with and notify students about events, workshops, resources and programming. 
+Build a community on popular social media platforms to connect with and notify students about events, workshops, resources and programming.
 
 Instagram is a popular social media choice amongst students for interaction with organizations. Increase engagement and reach a larger audience through Instagram posts, stories and by following student organizations.
 
@@ -61,15 +61,15 @@ LinkedIn is another popular social media platform for students to connect with p
 
 ### Host Tabling Events
 
-[Hosting a table at events](./event-tabling.md) either independently or in collaboration with other student organizations is an effective method of connecting with students. 
+[Hosting a table at events](./event-tabling.md) either independently or in collaboration with other student organizations is an effective method of connecting with students.
 
-Tables provide a fun and informal way to raise awareness of the OSPO's services. Short interactive games at the table can be used to educate students about the relevance of open source. 
+Tables provide a fun and informal way to raise awareness of the OSPO's services. Short interactive games at the table can be used to educate students about the relevance of open source.
 
 Event tabling at central locations on campus is particularly effective for outreach to diverse groups of students.
 
 ### Organize 'First Contribution' Workshops
 
-'First Contribution' Workshops offer a simple introduction to open source and demonstrate open source fundamentals in an engaging way. 
+'First Contribution' Workshops offer a simple introduction to open source and demonstrate open source fundamentals in an engaging way.
 
 Organize a workshop where students can learn a simple activity that can be uploaded onto a public website.
 
@@ -83,7 +83,7 @@ Using multiple outreach activities enhances the OSPO's potential to reach a wide
 
 ### Additional Learning from the GW Open Source Program Office
 
-We wanted to reach as many students as possible while helping them to understand what our OSPO offers. We found that the most effective ways to reach students included hiring Student Ambassadors, creating social media content, hosting tabling events, organizing workshops and hosting movie nights. These methods were easily applicable and offered a fun and interactive way to raise awareness of the OSPO and the importance of open source. 
+We wanted to reach as many students as possible while helping them to understand what our OSPO offers. We found that the most effective ways to reach students included hiring Student Ambassadors, creating social media content, hosting tabling events, organizing workshops and hosting movie nights. These methods were easily applicable and offered a fun and interactive way to raise awareness of the OSPO and the importance of open source.
 
 The OSPO hired 2 graduate students and 2 undergraduate students as Student Ambassadors. The OSPO now has its own [Instagram](https://www.instagram.com/gwospo/) and [LinkedIn](https://www.linkedin.com/company/ospo-gwuniversity) accounts.
 
@@ -106,8 +106,8 @@ We also used this [open source art repository](https://github.com/gw-ospo/open-s
 
 ## Contributors & Acknowledgements
 
-- Sunil Shah, George Washington University, https://orcid.org/0009-0009-4567-8679
-- Rosemary Pauley, George Washington University, https://orcid.org/0009-0008-9354-4301
-- Nouha Elyazidi, George Washington University, https://orcid.org/0009-0004-8067-8803
-- Jood Alfadhel, George Washington University, https://orcid.org/0009-0000-2827-4036
-- Ciara Flanagan, https://orcid.org/0009-0005-3153-7673
+- Sunil Shah, George Washington University, <https://orcid.org/0009-0009-4567-8679>
+- Rosemary Pauley, George Washington University, <https://orcid.org/0009-0008-9354-4301>
+- Nouha Elyazidi, George Washington University, <https://orcid.org/0009-0004-8067-8803>
+- Jood Alfadhel, George Washington University, <https://orcid.org/0009-0000-2827-4036>
+- Ciara Flanagan, <https://orcid.org/0009-0005-3153-7673>

--- a/student-showcase-sessions-at-ospo-events.md
+++ b/student-showcase-sessions-at-ospo-events.md
@@ -10,9 +10,11 @@ tags:
 # Student Showcase Sessions at OSPO Events
 
 ## Pattern Summary
-Create dedicated event/conference sessions where students present their open source projects, contributions or experiences working with their institution’s OSPO. 
+
+Create dedicated event/conference sessions where students present their open source projects, contributions or experiences working with their institution’s OSPO.
 
 ## Problem / Challenge
+
 The lack of recognition for open source work within academia causes valuable contributions to remain invisible and potentially undermines student motivation to participate in open source projects over the long-term.
 
 Without understanding open source's role in academia, students may overlook how open source experience can benefit their careers and academic work.
@@ -29,73 +31,84 @@ There may also be a limited awareness of the OSPO’s student-focused initiative
 - Supporting OSS development  
 
 ## Context
+
 A university with diverse departments of varying levels of OSS expertise and needs.
 
 An OSPO has been established.
 
 ## Forces
+
 An OSPO with the capacity to organize / co-organize events.
 
 An event or conference has been organized by the OSPO and a program committee is in place.
 
-OSPO staff have established connections with students and are familiar with open source projects. 
+OSPO staff have established connections with students and are familiar with open source projects.
 
 OSPO staff have the capacity to support students participating in showcase sessions.
 
 ## Solution
+
 Organize dedicated student showcase sessions as part of an open source conference or event.
 
 ### Planning
+
 The organizing committee may need to consider the following:
 
-* Potential scheduling conflicts with academic commitments.
-* How to make the Call for Presenters or application process inclusive for students.
-* Whether presentation coaching or promotional assistance is needed to support students to effectively communicate their work. 
-* How to encourage peer networking and establishing connections between students and faculty or industry during these sessions. 
-* Whether awards or recognition should be incorporated into the event e.g. best student project, best community impact.
+- Potential scheduling conflicts with academic commitments.
+- How to make the Call for Presenters or application process inclusive for students.
+- Whether presentation coaching or promotional assistance is needed to support students to effectively communicate their work.
+- How to encourage peer networking and establishing connections between students and faculty or industry during these sessions.
+- Whether awards or recognition should be incorporated into the event e.g. best student project, best community impact.
   
 ### Showcase Format
-Showcases may feature student presentations on a wide range of topics including (but not limited to) students’: 
 
-* Open source project contributions. 
-* Internship experiences.
-* Research involving open source tools.
-* Leadership roles within the institution’s OSPO.
+Showcases may feature student presentations on a wide range of topics including (but not limited to) students’:
+
+- Open source project contributions.
+- Internship experiences.
+- Research involving open source tools.
+- Leadership roles within the institution’s OSPO.
   
 Presentations may be in the form of lightning talks, poster sessions, panel discussions, community building sessions, demo formats or exhibits.
 
 ## Resulting Context
-* Student participants gain recognition and professional visibility for their open source contributions. 
-* They also develop valuable presentation experience.
-* Showcase sessions create a feedback loop that motivates continued student engagement with open source projects and OSPO activities. 
-* Faculty and industry attendees discover talented students for potential collaboration, internship, or hiring opportunities. 
-* The broader academic community develops greater awareness of student open source capabilities and the OSPO's educational impact. 
-* Showcases also generate content and success stories that the OSPO can use for recruitment, grant applications, and demonstrating value to institutional stakeholders.
+
+- Student participants gain recognition and professional visibility for their open source contributions.
+- They also develop valuable presentation experience.
+- Showcase sessions create a feedback loop that motivates continued student engagement with open source projects and OSPO activities.
+- Faculty and industry attendees discover talented students for potential collaboration, internship, or hiring opportunities.
+- The broader academic community develops greater awareness of student open source capabilities and the OSPO's educational impact.
+- Showcases also generate content and success stories that the OSPO can use for recruitment, grant applications, and demonstrating value to institutional stakeholders.
 
 ### Additional Learning from the Georgia Tech Open Source Program Office
-At this year’s conference, we gave students more of a spotlight to present their work. Some of the students who participated in last year’s [virtual summer internship program](https://ospo.cc.gatech.edu/vsip/) spoke about the experience and their progress on projects. It was very successful and we had greater numbers of students participating than at the previous conference. 
+
+At this year’s conference, we gave students more of a spotlight to present their work. Some of the students who participated in last year’s [virtual summer internship program](https://ospo.cc.gatech.edu/vsip/) spoke about the experience and their progress on projects. It was very successful and we had greater numbers of students participating than at the previous conference.
 
 Because of the success of the student panels, we plan to split the format next year. We hope to run our usual annual summit (where speakers present their results) and add a separate workshop focused on training.
 
 ## Known Instances
+
 [Georgia Tech Open Source Program Office](https://ospo.cc.gatech.edu/), Georgia Institute of Technology
 
 ## References
+
 Scroll down the agenda for the [Open Source and Scientific Software Workshop](https://ospo.cc.gatech.edu/ospo-sse-workshop-2025/) for details of the student lightning talks.
 
 ### Related Patterns
-* [Co-hosting student events](./cohosting-student-events.md)
-* [Facilitate connections at Open Source Conferences](./facilitate-connections-at-open-source-conferences.md)
-* [Host an Open Source Conference](./host-an-open-source-conference.md)
-* [Informal OSPO focus group sessions at Open Source Events](./informal-ospo-focus-groups-at-open-source-events.md)
-* [Piggyback onto a larger conference](piggyback-onto-a-larger-conference.md)
-* [Secure Sponsorship for an Open Source Conference](./secure-sponsorship-for-an-open-source-conference.md)
-* [Senior Leadership Keynote](./senior-leadership-keynote.md)
-* [Summer Internship Program](./summer-internship-program.md)
+
+- [Co-hosting student events](./cohosting-student-events.md)
+- [Facilitate connections at Open Source Conferences](./facilitate-connections-at-open-source-conferences.md)
+- [Host an Open Source Conference](./host-an-open-source-conference.md)
+- [Informal OSPO focus group sessions at Open Source Events](./informal-ospo-focus-groups-at-open-source-events.md)
+- [Piggyback onto a larger conference](piggyback-onto-a-larger-conference.md)
+- [Secure Sponsorship for an Open Source Conference](./secure-sponsorship-for-an-open-source-conference.md)
+- [Senior Leadership Keynote](./senior-leadership-keynote.md)
+- [Summer Internship Program](./summer-internship-program.md)
 
 ## Contributors & Acknowledgement
+
 In alphaetical order
 
-* Ciara Flanagan, https://orcid.org/0009-0005-3153-7673
-* Fang Liu, Georgia Institute of Technology, https://orcid.org/0000-0002-3383-2191 
-* Jeff Young, Georgia Institute of Technology,, https://orcid.org/0000-0001-9841-4057
+- Ciara Flanagan, <https://orcid.org/0009-0005-3153-7673>
+- Fang Liu, Georgia Institute of Technology, <https://orcid.org/0000-0002-3383-2191>
+- Jeff Young, Georgia Institute of Technology,, <https://orcid.org/0000-0001-9841-4057>

--- a/summer-internship-program.md
+++ b/summer-internship-program.md
@@ -37,14 +37,14 @@ The industry collaborators have an in-depth understanding of open source project
 
 Develop a mentor-led summer internship program that offers opportunities to contribute to open source projects with ‘real-world’ clients in industry and/or across faculty.
 
-The program may be delivered virtually or on campus. 
+The program may be delivered virtually or on campus.
 
 The solution below outlines basic core activities to consider:
 
 ### Outreach to potential partners
 
 * Conduct outreach to potential partners in industry, open source projects and/or within the university to gauge interest in participating.  
-    
+
 * A consultation exercise with potential industry and/or faculty partners may be necessary to determine ‘what works’ for industry and open source partners; and the type of training that will be most useful for the campus community.
 
 ### Design of internship program
@@ -63,15 +63,15 @@ The solution below outlines basic core activities to consider:
 
 * Students may also be tasked with delivering outputs to benefit their university.
 
-* Each internship may be allocated on an individual basis or to student teams. 
+* Each internship may be allocated on an individual basis or to student teams.
 
 ### Advertising to student population
 
 * A transparent selection process for candidates should be put in place.
 
-* Target the student cohort to advertise the internship program.   
-    
-* Information sessions are useful promotional tools during this period. This [information session](https://mediaspace.gatech.edu/media/Georgia+Tech+OSPO+Summer+Internship+-+Informational+Meeting+-+February+27th%2C+2024/1_x91gms33) includes lightning talks from participating organizations. 
+* Target the student cohort to advertise the internship program.
+
+* Information sessions are useful promotional tools during this period. This [information session](https://mediaspace.gatech.edu/media/Georgia+Tech+OSPO+Summer+Internship+-+Informational+Meeting+-+February+27th%2C+2024/1_x91gms33) includes lightning talks from participating organizations.
 
 ### Grading / evaluating students
 
@@ -88,35 +88,35 @@ Students may be graded in a number of ways including:
 
 ## Resulting Context
 
-Students develop their occupational skills and learn about how software develops at scale. 
+Students develop their occupational skills and learn about how software develops at scale.
 
 Students have an opportunity to build new contacts with potential employers.
 
-The program also  presents opportunities for developing important soft skills in client communications, project management, and leadership that fall outside of many traditional technology-focused internship opportunities. 
+The program also  presents opportunities for developing important soft skills in client communications, project management, and leadership that fall outside of many traditional technology-focused internship opportunities.
 
-## Additional learning 
+## Additional learning
 
 ### Additional Learning from Carnegie Mellon University OSPO on the Semesters of Code program
 
-* Placing students in teams reflects the real world of software engineering with all the intra-team communications required. This structure also relieves instructor and mentor load.   
+* Placing students in teams reflects the real world of software engineering with all the intra-team communications required. This structure also relieves instructor and mentor load.
 * Mentors from Red Hat Linux, Eclipse Foundation, and local Pittsburgh startups said they would eagerly offer 14 students (out of the 15 participants) not only internships but also jobs upon graduation.  
 * The peer to peer mentoring that took place on student teams was particularly noteworthy. One of the most rewarding and illuminating outcomes was the rise of student mentors who have continued to show advanced skills one year later.  
 
-Our model presents opportunities for developing important soft skills in client communications, project management, and leadership that fall outside of many traditional technology-focused internship opportunities. 
+Our model presents opportunities for developing important soft skills in client communications, project management, and leadership that fall outside of many traditional technology-focused internship opportunities.
 
 We successfully met our objective of providing students with the opportunity to experience software engineering in its reality of intra-team communications, software development and delivery at scale. Their internship experiences demonstrated to them that delivering software is about considerably more than “writing the code.”
 
 ### Additional learning from the Georgia Tech OSPO on the Virtual Summer Internship Program (VSIP)
 
-This is an evolving process but we’ve already seen some initial increase in awareness amongst our 30 program participants. 
+This is an evolving process but we’ve already seen some initial increase in awareness amongst our 30 program participants.
 
-We plan to continue making improvements to this program and to possibly turn it into a micro-badging program that can be shared with our constituents in an asynchronous fashion. 
+We plan to continue making improvements to this program and to possibly turn it into a micro-badging program that can be shared with our constituents in an asynchronous fashion.
 
 Our hope is that we can use this initial engagement with the internship program as a seed for a wide-reaching, asynchronous and open educational framework that can extend the reach of our OSPO.
 
-As part of this program, we have been working on [open source training notebooks](https://github.com/gt-ospo/oss-training), which present a variety of topics that should enable students and faculty at Georgia Tech to improve the quality of their open source projects. 
+As part of this program, we have been working on [open source training notebooks](https://github.com/gt-ospo/oss-training), which present a variety of topics that should enable students and faculty at Georgia Tech to improve the quality of their open source projects.
 
-One challenge may be that we should be careful to work closely with other OSPOs and OSS organizations to make sure we are not “recreating” existing resources. A good example of this is our open source code review lecture, which relies heavily on [BSSW’s code review example project](https://code-review.org). 
+One challenge may be that we should be careful to work closely with other OSPOs and OSS organizations to make sure we are not “recreating” existing resources. A good example of this is our open source code review lecture, which relies heavily on [BSSW’s code review example project](https://code-review.org).
 
 ## Known Instances
 
@@ -131,24 +131,25 @@ One challenge may be that we should be careful to work closely with other OSPOs 
 * [Training modules for getting started with open source software development](https://github.com/gt-ospo/oss-training) - Open training notebooks developed for VSIP students that will also enable other students and faculty to improve the quality of their open source projects. (Materials remain under development.)
 
 ### Related Patterns
+
 [Student Showcase Sessions at OSPO Events](./student-showcase-sessions-at-ospo-events.md)
 [Open Source Capstone Course](https://github.com/CURIOSSorg/curioss-patterns/blob/main/open-source-capstone-course.md)
 
-- [Open Research Community Accelerator](./open-research-community-accelerator.md)
-- [Open Source Capstone Course](./open-source-capstone-course.md)
-- [Student Showcase Sessions at OSPO Events](./student-showcase-sessions-at-ospo-events.md)
+* [Open Research Community Accelerator](./open-research-community-accelerator.md)
+* [Open Source Capstone Course](./open-source-capstone-course.md)
+* [Student Showcase Sessions at OSPO Events](./student-showcase-sessions-at-ospo-events.md)
 
 ## Contributor(s) & Acknowledgment
 
 * Sayeed Choudhury (Carnegie Mellon University)
 * Clare Dillon (CURIOSS) [https://orcid.org/0009-0008-6205-0296](https://orcid.org/0009-0008-6205-0296)
 * Ciara Flanagan [https://orcid.org/0009-0005-3153-7673](https://orcid.org/0009-0005-3153-7673)  
-* Tom Hughes (Carnegie Mellon University) https://orcid.org/0009-0008-7516-3687  
-* Fang Liu (Georgia Institute of Technology) https://orcid.org/0000-0002-3383-2191  
-* Jeffrey Young (Georgia Institute of Technology) https://orcid.org/0000-0001-9841-4057
+* Tom Hughes (Carnegie Mellon University) <https://orcid.org/0009-0008-7516-3687>  
+* Fang Liu (Georgia Institute of Technology) <https://orcid.org/0000-0002-3383-2191>  
+* Jeffrey Young (Georgia Institute of Technology) <https://orcid.org/0000-0001-9841-4057>
 * Stephen Walli (Microsoft)  
 
-### Thanks to:
+### Thanks to
 
 * Dr. Michael Hilton (Carnegie Mellon University)  
 * Brad Topol and Susan Malaika (IBM)  

--- a/supporting-grant-proposals-with-an-open-source-component.md
+++ b/supporting-grant-proposals-with-an-open-source-component.md
@@ -31,11 +31,11 @@ PIs, other leaders, and central institution or departmental grants offices are i
 
 ## Forces
 
-Teams working on proposals face competing pressures and time constraints when submitting proposals and their primary concern is the proposal narrative and budget. 
+Teams working on proposals face competing pressures and time constraints when submitting proposals and their primary concern is the proposal narrative and budget.
 
 Other components of a grant application (e.g. open source, OSS) is outside their area of expertise and/or their area of concern.
 
-Other offices that focus on grant submissions may not know of the university OSPO and how it can support their funding applications. 
+Other offices that focus on grant submissions may not know of the university OSPO and how it can support their funding applications.
 
 ## Solution
 
@@ -45,7 +45,7 @@ The solution below outlines basic core activities to consider.
 
 ### Raising awareness with key stakeholders
 
-Develop approaches for marketing OSPO support in this area with relevant faculty, researchers and senior leadership. 
+Develop approaches for marketing OSPO support in this area with relevant faculty, researchers and senior leadership.
 
 Ideally, awareness raising activities should be conducted well in advance of any funding application deadlines. OSPO support for grant proposals can be communicated in:
 
@@ -65,7 +65,7 @@ Depending on capacity, options for grant support may include:
 * Consultation that leads to changes in the proposal narrative by the leadership team.
 * Letters of support or appendices that outline the services of the OSPO and other relevant teams (e.g. open science, open access), through associated templates.
 * Letters or appendices of commitment that outline specific contributions from the OSPO toward the deliverables of the proposal.
-* Recommendations regarding third party experts, organizations, etc. that could improve the chances of funding approval. 
+* Recommendations regarding third party experts, organizations, etc. that could improve the chances of funding approval.
 * Including OSPO personnel as members of the proposal team.
 
 ## Resulting Context
@@ -82,11 +82,11 @@ Possibly better reactions from reviewers interested in the open source component
 
 We regularly work with CMU’s Open Science team to provide information about our services.
 
-To date, faculty have directly contacted the OSPO for proposal support. The CMU OSPO offers to meet with the leadership team, which has often taken advantage of this opportunity. 
+To date, faculty have directly contacted the OSPO for proposal support. The CMU OSPO offers to meet with the leadership team, which has often taken advantage of this opportunity.
 
-In some cases, requests have come from departmental or college-level research support departments seeking additional expertise in support of faculty proposals. 
+In some cases, requests have come from departmental or college-level research support departments seeking additional expertise in support of faculty proposals.
 
-In all cases, the OSPO asks for a copy of the proposal, which is reviewed for any mention of or opportunity related to open source software. 
+In all cases, the OSPO asks for a copy of the proposal, which is reviewed for any mention of or opportunity related to open source software.
 
 We’ve also noted a greater awareness and appreciation for the CMU OSPO and we’ve used this as an opportunity to introduce projects to other services such as [Bitergia](https://bitergia.com/) and [Scarf](https://about.scarf.sh/).
 
@@ -99,13 +99,14 @@ We’ve also noted a greater awareness and appreciation for the CMU OSPO and we�
 ## References
 
 ### Related Patterns
+
 * [Embedding the OSPO as Research Infrastructure](./embedding-the-ospo-as-research-infrastructure.md) - Pattern from the UT Austin OSPO.
 * [Open Source Grant Commitment Letter](./open-source-grant-commitment-letter.md) - Pattern from the George Washington University OSPO.
 * [OSPO as Co-Principal Investigator](./ospo-as-co-principal-investigator.md)
 * [OSPO as *Lead* Principal Investigator](./ospo-as-lead-principal-investigator.md)
 
 ## Contributors & Acknowledgement
-* Sayeed Choudhury (Carnegie Mellon University) https://orcid.org/0000-0003-2891-0543
-* Tom Hughes (Carnegie Mellon University) https://orcid.org/0009-0008-7516-3687
-* Ciara Flanagan https://orcid.org/0009-0005-3153-7673
 
+* Sayeed Choudhury (Carnegie Mellon University) <https://orcid.org/0000-0003-2891-0543>
+* Tom Hughes (Carnegie Mellon University) <https://orcid.org/0009-0008-7516-3687>
+* Ciara Flanagan <https://orcid.org/0009-0005-3153-7673>

--- a/template-for-1-1-campus-consultations.md
+++ b/template-for-1-1-campus-consultations.md
@@ -10,7 +10,7 @@ tags:
 
 ## Pattern Summary
 
-Use a standard template for individual consultations to understand an open source project’s status, its challenges, how it’s resourced and critical next steps. 
+Use a standard template for individual consultations to understand an open source project’s status, its challenges, how it’s resourced and critical next steps.
 
 ## Problem / Challenge
 
@@ -26,11 +26,11 @@ Academic OSPOs may be constrained by the number of individual consultations/offi
 
 Below is a list of common categories of academic OSPO activities \- please choose which apply:
 
-- Building University OSS Community
-- Sharing OSS Best Practices  
-- Working with Tech Transfer / External Partners  
-- Supporting OSS development  
-- Funding & Financial Support
+* Building University OSS Community
+* Sharing OSS Best Practices  
+* Working with Tech Transfer / External Partners  
+* Supporting OSS development  
+* Funding & Financial Support
 
 ## Context
 
@@ -50,34 +50,35 @@ OSPO staff have the capacity/availability to meet for consultations and to provi
 
 Develop a template that guides the OSPO to explore some or all of the following areas within the meeting timeframe:
 
-- Basic contact information, website links and/or repository details.
-- Project context and project description.
-- The project’s stage of development.
-- Current challenges and priorities.
-- Resourcing needs.
-- Next steps for the project.
-- Follow-up support to be offered by the OSPO.
+* Basic contact information, website links and/or repository details.
+* Project context and project description.
+* The project’s stage of development.
+* Current challenges and priorities.
+* Resourcing needs.
+* Next steps for the project.
+* Follow-up support to be offered by the OSPO.
 
 ## Resulting Context
 
 Academic OSPOs have a consultation template that serves as a:
-- Diagnostic tool for open source projects.
-- Framework that supports students, researchers and faculty at different points of open source development to deepen their understanding of their needs and objectives.
-- A structured knowledge base that enables OSPO staff to provide meaningful and consistent support.
-- A consistent and comparable record of consultations.
+
+* Diagnostic tool for open source projects.
+* Framework that supports students, researchers and faculty at different points of open source development to deepen their understanding of their needs and objectives.
+* A structured knowledge base that enables OSPO staff to provide meaningful and consistent support.
+* A consistent and comparable record of consultations.
 
 ### Additional Learning from Carnegie Mellon University OSPO
 
 We use two templates to guide conversation with projects and to assess their needs. The intention is to offer formats that could be used individually or combined to adapt to the learning and interaction styles of any group.
 
-The first template is in the form of a slide deck that allows for a collaborative workshop model akin to ‘virtual post-it notes’ for more visual and collaborative groups. 
+The first template is in the form of a slide deck that allows for a collaborative workshop model akin to ‘virtual post-it notes’ for more visual and collaborative groups.
 
-The second template is a more traditional google doc for individuals who prefer a longer form, written style. 
+The second template is a more traditional google doc for individuals who prefer a longer form, written style.
 
 ## Known Instances
 
-- [CMU Open Source Program Office](https://www.library.cmu.edu/services/ospo), CMU Libraries, Carnegie Mellon University
-- [GW Open Source Program Office](https://ospo.gwu.edu/), The George Washington University
+* [CMU Open Source Program Office](https://www.library.cmu.edu/services/ospo), CMU Libraries, Carnegie Mellon University
+* [GW Open Source Program Office](https://ospo.gwu.edu/), The George Washington University
 
 ## References
 
@@ -85,11 +86,13 @@ The second template is a more traditional google doc for individuals who prefer 
 * [The OSPO Project Consultation Worksheet](https://docs.google.com/document/d/11r6_S6bf6bMIKB7OW7B4IQFIjzIoYwnJzEvOb3fmd40/edit?tab=t.0#heading=h.1logflb8o65z) by Carnegie Mellon University OSPO
 
 ### Related Patterns
+
 [Individual Consultations/Office Hours](./individual-consultations-office-hours.md)
 
 ## Contributors & Acknowledgement
 
 (in alphabetical order)
-* Ciara Flanagan, https://orcid.org/0009-0005-3153-7673
+
+* Ciara Flanagan, <https://orcid.org/0009-0005-3153-7673>
 * Duane O'Brien consulted on the design of the CMU OSPO project consultation template
-* Tom Hughes (Carnegie Mellon University), https://orcid.org/0009-0008-7516-3687
+* Tom Hughes (Carnegie Mellon University), <https://orcid.org/0009-0008-7516-3687>


### PR DESCRIPTION
This commit lints all files to match best practices for Markdown. Further:

- Auto-fixed (≈80 issues): ran npm run lint-fix which resolved all MD022 (blanks-around-headings) and MD032 (blanks-around-lists) issues across ~20 files.
- embedding-the-ospo-as-research-infrastructure.md: bumped every heading up one level (h3→h2, h4→h3) — the whole file was offset under the h1 title.
- open-source-software-prize.md: stripped the redundant ### Pattern Theme / Category section (body bullets all mapped to existing frontmatter tags), and promoted **Open Source Project Awards** / **Individual Contributor Awards** from bold to ### headings.
- oss-tutorials-using-authoring-tools.md: promoted the bold "Excerpt from the poem…" line to an ### heading.
set-up-an-ospo-giving-page.md: renamed the inner h3 from "Set up an OSPO Giving Page" to "Build the giving page" to avoid duplicating the pages H1 title.