### PR TITLE
Show the official ORCID iD icon next to ORCID links

### DIFF
--- a/.config/hooks/authors.py
+++ b/.config/hooks/authors.py
@@ -20,12 +20,23 @@ from mkdocs.exceptions import PluginError
 from mkdocs.structure.files import File
 
 AUTHORS_FILE = "authors.yml"
+ORCID_ICON = "assets/orcid-id.svg"
 CONTRIB_HEADING_RE = re.compile(
     r"^##\s+Contributors\s*&\s*Acknowledg\w*\s*$",
     re.MULTILINE,
 )
 BULLET_LINE_RE = re.compile(r"^\s*[-*]\s+\S")
 HEADING_RE = re.compile(r"^#+\s", re.MULTILINE)
+
+
+def _orcid_markdown(orcid: str, asset_prefix: str) -> str:
+    """Render an ORCID iD with the official icon, wrapped in a link.
+
+    ``asset_prefix`` is "" for source pages at the docs root and "../" for
+    generated pages under ``authors/``.
+    """
+    icon = f"![ORCID iD icon]({asset_prefix}{ORCID_ICON})"
+    return f"[{icon} {orcid}](https://orcid.org/{orcid})"
 
 
 def _load_authors(docs_dir: str) -> dict:
@@ -101,7 +112,7 @@ def _render_authors_index(
         name = record.get("name", slug)
         aff = record.get("affiliation") or ""
         orcid = record.get("orcid")
-        orcid_cell = f"[{orcid}](https://orcid.org/{orcid})" if orcid else ""
+        orcid_cell = _orcid_markdown(orcid, "../") if orcid else ""
         lines.append(f"| [{name}](#{slug}) | {aff} | {orcid_cell} |")
 
     for slug, record in sorted_authors:
@@ -112,7 +123,7 @@ def _render_authors_index(
         if aff:
             lines += [f"**Affiliation:** {aff}", ""]
         if orcid:
-            lines += [f"**ORCID:** [{orcid}](https://orcid.org/{orcid})", ""]
+            lines += [f"**ORCID:** {_orcid_markdown(orcid, '../')}", ""]
         lines += ["**Patterns:**", ""]
         patterns = by_author.get(slug, [])
         if patterns:
@@ -136,7 +147,7 @@ def _render_pattern_bullets(slugs: list[str], authors_map: dict) -> str:
         if aff:
             extras.append(aff)
         if orcid:
-            extras.append(f"[ORCID](https://orcid.org/{orcid})")
+            extras.append(_orcid_markdown(orcid, ""))
         if extras:
             line += " — " + ", ".join(extras)
         bullets.append(line)

--- a/assets/orcid-id.svg
+++ b/assets/orcid-id.svg
@@ -1,0 +1,9 @@
+<!--
+  Official ORCID iD icon.
+  Source: https://info.orcid.org/brand-guidelines/
+  Per ORCID's brand guidelines, this icon may be used to identify an ORCID iD.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 256 256" aria-label="ORCID iD icon" role="img">
+  <path d="M256 128c0 70.7-57.3 128-128 128S0 198.7 0 128 57.3 0 128 0s128 57.3 128 128z" fill="#A6CE39"/>
+  <path fill="#fff" d="M86.3 186.2H70.9V79.1h15.4v107.1zM108.9 79.1h41.6c39.6 0 57 28.3 57 53.6 0 27.5-21.5 53.6-56.8 53.6h-41.8V79.1zm15.4 93.3h24.5c34.9 0 42.9-26.5 42.9-39.7 0-21.5-13.7-39.7-43.7-39.7h-23.7v79.4zM88.7 56.8c0 5.5-4.5 10.1-10.1 10.1s-10.1-4.6-10.1-10.1c0-5.6 4.5-10.1 10.1-10.1s10.1 4.6 10.1 10.1z"/>
+</svg>


### PR DESCRIPTION
Builds on top of #141.

## What this changes

Right now, an ORCID on an author's page or in a pattern's contributor list shows up as the word "ORCID" or the bare ORCID number. This PR adds the official ORCID iD icon (the small green roundel you see on ORCID's own site and on most academic profile pages) next to those numbers. It's a small visual change — purely cosmetic — but it makes ORCIDs instantly recognisable as ORCIDs at a glance.

## Where you'll see it

- **On each author's page** — next to "**ORCID:**", you'll now see the green icon followed by the ORCID number, all of it clickable.
- **In the contributors section at the bottom of a pattern** — each author entry's ORCID link now shows the icon next to the number instead of the word "ORCID".

## What to click on the preview site

- `/authors/ciara-flanagan/` — Ciara's page; the ORCID line at the top has the icon now.
- `/embed-wellbeing-into-student-hackathons/` — scroll to Contributors; each contributor's ORCID is shown with the icon.

## What this doesn't change

- No changes to contributor workflow. You still add yourself the same way.
- No changes to which authors have ORCIDs displayed; authors without an ORCID in `authors.yml` continue to show no ORCID line, same as before.
- The icon comes from ORCID's own brand guidelines page, used in line with their published guidance.

## Stacking

This PR is stacked on top of #141 — please merge that one first. Once #141 is in, this one rebases automatically onto `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)