### PR TITLE
Stop the link checker flagging the Authors page

### DIFF
--- a/mdlinkcheckconfig.json
+++ b/mdlinkcheckconfig.json
@@ -1,6 +1,7 @@
 {
   "aliveStatusCodes": [0, 200, 202, 403, 415, 417],
   "ignorePatterns": [
-    { "pattern": "^https?://(www\\.)?instagram\\.com/" }
+    { "pattern": "^https?://(www\\.)?instagram\\.com/" },
+    { "pattern": "^authors/index\\.md" }
   ]
 }


### PR DESCRIPTION
### What this does

Our automated link checker was reporting a broken link on the Contributing page — the link to the **Authors page**. This fixes that.

### Why it was happening

The Authors page isn't a file we write by hand; the website builds it automatically from `authors.yml` every time the site is published. Because the page only exists *after* the site is built, our link-checking tool — which looks at the files in the repository — couldn't find it and assumed the link was broken. It wasn't: the link works perfectly on the live site.

### The fix

This tells the link checker to skip that one automatically-generated page, while still checking every other link as before. The website's own build process continues to verify the link properly, so nothing is lost.

No content or wording changes — this only affects the automated check.